### PR TITLE
Feature/adminheader

### DIFF
--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -79,14 +79,43 @@ const Header = () => {
             Vetting
           </Nav.Link>
           <RoleAuthenticator alt={<></>} roles={[ROLE.ADMIN]}>
-            <Nav.Link
+            {/* <Nav.Link
               as={Link}
               to="admin"
               className={`${getActiveClass(headerTabs.ADMIN)}`}
               onClick={() => clickTab(headerTabs.ADMIN)}
             >
               Admin
-            </Nav.Link>
+            </Nav.Link> */}
+            <NavDropdown title="Admin" id="nav-dropdown">
+              <NavDropdown.Item as={Link} to="admin/manageusers">
+                Manage Users
+              </NavDropdown.Item>
+              <NavDropdown.Item as={Link} to="admin/auditlog">
+                Audit Log
+              </NavDropdown.Item>
+              <NavDropdown.Item as={Link} to="admin/errorlog">
+                Error Log
+              </NavDropdown.Item>
+              <NavDropdown.Item as={Link} to="admin/settings">
+                Settings
+              </NavDropdown.Item>
+              <NavDropdown.Item as={Link} to="admin/filedownload">
+                File Download
+              </NavDropdown.Item>
+              <NavDropdown.Item as={Link} to="admin/codeeditor">
+                Code Editor
+              </NavDropdown.Item>
+              <NavDropdown.Item as={Link} to="admin/loaderstats">
+                Loader Statistics
+              </NavDropdown.Item>
+              <NavDropdown.Item as={Link} to="admin/watchlistcats">
+                Watchlist Categories
+              </NavDropdown.Item>
+              <NavDropdown.Item as={Link} to="admin/notetypecats">
+                Note Type Categories
+              </NavDropdown.Item>
+            </NavDropdown>
           </RoleAuthenticator>
           <NavDropdown title="Tools" id="nav-dropdown">
             <NavDropdown.Item as={Link} to="tools/queries" onClick={() => clickTab("")}>

--- a/src/components/title/Title.css
+++ b/src/components/title/Title.css
@@ -16,7 +16,8 @@
 .left-span {
   position: absolute;
   left: 0px;
-  top: 0px;
+  top: 5px;
+  font-size: initial;
 }
 
 .right-span {

--- a/src/components/title/Title.css
+++ b/src/components/title/Title.css
@@ -6,15 +6,21 @@
   font-size: x-large;
   font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
   padding: 5px;
+  position: relative;
 }
 
 .title-span {
-  padding-right: 116px;
   flex-grow: 1;
 }
 
 .left-span {
-  float: left;
-  font-size: initial;
-  margin-bottom: -6px;
+  position: absolute;
+  left: 0px;
+  top: 0px;
+}
+
+.right-span {
+  position: absolute;
+  right: 0px;
+  top: 0px;
 }

--- a/src/pages/admin/Admin.js
+++ b/src/pages/admin/Admin.js
@@ -24,8 +24,8 @@ const Admin = props => {
         text="Something has happened."
         defaultState={showBanner}
       />
-
-      <Tabs tabs={tablist} />
+      {props.children}
+      {/* <Tabs tabs={tablist} /> */}
     </>
   );
 };

--- a/src/pages/admin/codeEditor/CodeEditor.js
+++ b/src/pages/admin/codeEditor/CodeEditor.js
@@ -3,7 +3,9 @@ import Tabs from "../../../components/tabs/Tabs";
 import Banner from "../../../components/banner/Banner";
 
 const CodeEditor = props => {
-  const tabcontent = props.children;
+  const tabcontent = props.children.props.children;
+
+  console.log(props.children);
 
   const tablist = tabcontent.map((tab, idx) => {
     return { title: tab.props.name, key: tab.props.name, link: tab };

--- a/src/pages/admin/fileDownload/FileDownload.js
+++ b/src/pages/admin/fileDownload/FileDownload.js
@@ -5,6 +5,7 @@ import Title from "../../../components/title/Title";
 import { Container } from "react-bootstrap";
 import LabelledInput from "../../../components/labelledInput/LabelledInput";
 import { asArray, hasData } from "../../../utils/utils";
+import "./fileDownload.css";
 
 const FileDownload = ({ name }) => {
   const [logTypes, setLogTypes] = useState([]);

--- a/src/pages/admin/fileDownload/FileDownload.js
+++ b/src/pages/admin/fileDownload/FileDownload.js
@@ -1,10 +1,10 @@
-import React, {useEffect, useState} from "react";
+import React, { useEffect, useState } from "react";
 import Table from "../../../components/table/Table";
-import {logfile, paxdetailsReport, users} from "../../../services/serviceWrapper";
+import { logfile, paxdetailsReport, users } from "../../../services/serviceWrapper";
 import Title from "../../../components/title/Title";
 import { Container } from "react-bootstrap";
 import LabelledInput from "../../../components/labelledInput/LabelledInput";
-import {asArray, hasData} from "../../../utils/utils";
+import { asArray, hasData } from "../../../utils/utils";
 
 const FileDownload = ({ name }) => {
   const [logTypes, setLogTypes] = useState([]);
@@ -15,95 +15,97 @@ const FileDownload = ({ name }) => {
   const [currentLogType, setCurrentLogType] = useState("");
   const cb = function(result) {};
 
-  const onLogTypeSelect = (target) => {
-      let logFileType = target.selectedOptions[0].value;
-      if (hasData(logFileType) && logFileType != ""){
-          getLogFilesList(logFileType);
-          setTblId(logFileType);
-          setCurrentLogType(logFileType);
-      } else{
-          setData([]);
-          setTblId("No Log Files Found");
-          setTblRefreshKey(tblRefreshKey+1);
-          setCurrentLogType("");
-      }
+  const onLogTypeSelect = target => {
+    let logFileType = target.selectedOptions[0].value;
+    if (hasData(logFileType) && logFileType != "") {
+      getLogFilesList(logFileType);
+      setTblId(logFileType);
+      setCurrentLogType(logFileType);
+    } else {
+      setData([]);
+      setTblId("No Log Files Found");
+      setTblRefreshKey(tblRefreshKey + 1);
+      setCurrentLogType("");
+    }
   };
 
-  const getLogFilesList = (logFileType) =>{
-      logfile.get(undefined,logFileType).then(res =>{
-         setData(res);
-         setTblRefreshKey(tblRefreshKey+1);
+  const getLogFilesList = logFileType => {
+    logfile.get(undefined, logFileType).then(res => {
+      setData(res);
+      setTblRefreshKey(tblRefreshKey + 1);
+    });
+  };
+
+  //Get logtypes for dropdown selection
+  useEffect(() => {
+    if (logTypes.length === 0) {
+      logfile.get().then(res => {
+        setLogTypes(parseLogTypes(res));
+        setSelRefreshKey(selRefreshKey + 1);
       });
+    }
+  }, []);
+  //Parse log types return into array of values for select
+  const parseLogTypes = res => {
+    if (res) {
+      return asArray(res).map(logType => {
+        return {
+          value: logType,
+          label: logType
+        };
+      });
+    }
+    return [];
   };
 
-    //Get logtypes for dropdown selection
-    useEffect(() => {
-        if(logTypes.length === 0){
-            logfile.get().then(res => {
-                setLogTypes(parseLogTypes(res));
-                setSelRefreshKey(selRefreshKey+1);
-            });
-        };
-    }, []);
-    //Parse log types return into array of values for select
-    const parseLogTypes = (res) => {
-        if(res){
-            return asArray(res).map(logType => {
-                return {
-                    value: logType,
-                    label: logType
-                };
-            });
-        };
-      return [];
-    };
+  const downloadFile = rowDetails => {
+    console.log(rowDetails);
+    logfile.download(currentLogType + "/" + rowDetails.fileName);
+  };
 
-    const downloadFile = (rowDetails) => {
-      console.log(rowDetails);
-      logfile.download(currentLogType+"/"+rowDetails.fileName);
-    };
+  const headers = [
+    {
+      Accessor: "Download",
+      Cell: ({ row }) => {
+        return (
+          <div className="icon-col">
+            <i
+              className="fa fa-pencil-square-o qbrb-icon"
+              onClick={() => downloadFile(row.original)}
+            ></i>
+          </div>
+        );
+      }
+    },
+    { Accessor: "fileName" },
+    { Accessor: "size" },
+    { Accessor: "createDate" },
+    { Accessor: "lastModified" }
+  ];
 
-    const headers = [
-        {
-            Accessor: "Download",
-            Cell: ({ row }) => {
-                return (
-                    <div className="icon-col">
-                        <i
-                            className="fa fa-pencil-square-o qbrb-icon"
-                            onClick={() => downloadFile(row.original)}
-                        ></i>
-                    </div>
-                );
-            }
-        },
-        { Accessor: "fileName" },
-        { Accessor: "size" },
-        { Accessor: "createDate" },
-        { Accessor: "lastModified" }
-    ];
-
+  const fileTypeCtrl = (
+    <LabelledInput
+      inputType="select"
+      inputStyle="file-type"
+      name="severity"
+      placeholder="Choose Log Type..."
+      options={logTypes}
+      required={true}
+      alt="nothing"
+      callback={onLogTypeSelect}
+      key={selRefreshKey}
+    />
+  );
 
   return (
-
     <Container fluid>
-      <Title title={name}></Title>
-        <LabelledInput
-            labelText="LogTypes"
-            inputType="select"
-            name="severity"
-            placeholder="Choose Log Type..."
-            options={logTypes}
-            required={true}
-            alt="nothing"
-            callback={onLogTypeSelect}
-            key={selRefreshKey}
-        />
-      <Table id={tblId}
-             callback={cb}
-             key={tblRefreshKey}
-             data={data}
-             header={headers}
+      <Title title={name} rightChild={fileTypeCtrl}></Title>
+      <Table
+        id={tblId}
+        callback={cb}
+        key={tblRefreshKey}
+        data={data}
+        header={headers}
       ></Table>
     </Container>
   );

--- a/src/pages/admin/fileDownload/fileDownload.css
+++ b/src/pages/admin/fileDownload/fileDownload.css
@@ -1,3 +1,3 @@
-.file-type {
+.right-span > .form-group {
   padding-top: 6px;
 }

--- a/src/pages/admin/fileDownload/fileDownload.css
+++ b/src/pages/admin/fileDownload/fileDownload.css
@@ -1,0 +1,3 @@
+.file-type {
+  padding-top: 6px;
+}

--- a/src/pages/admin/loaderStats/LoaderStats.js
+++ b/src/pages/admin/loaderStats/LoaderStats.js
@@ -3,6 +3,7 @@ import LabelledInput from "../../../components/labelledInput/LabelledInput";
 import Form from "../../../components/form/Form";
 import { loaderStats } from "../../../services/serviceWrapper";
 import { Container, Col } from "react-bootstrap";
+import Title from "../../../components/title/Title";
 
 const LoaderStats = ({ name }) => {
   const cb = function(result) {};
@@ -18,66 +19,70 @@ const LoaderStats = ({ name }) => {
   }, []);
 
   return (
-    <Container>
-      <Col lg={{ span: 4, offset: 4 }}>
-        <Form data={data} key={key} title="" callback={cb} submitText="Refresh">
-          <LabelledInput
-            datafield
-            labelText="Last message received:"
-            inputType="text"
-            name="lastMessageInSystem"
-            alt="Last message received"
-            readOnly
-            callback={onChange}
-          />
-          <LabelledInput
-            datafield
-            labelText="Last message analyzed:"
-            inputType="text"
-            name="lastMessageAnalyzedByDrools"
-            callback={onChange}
-            readOnly
-            alt="Last message analyzed"
-          />
-          <LabelledInput
-            datafield
-            labelText="Most recent rule hit (Partial excluded) timestamp:"
-            inputType="text"
-            name="mostRecentRuleHit"
-            callback={onChange}
-            readOnly
-            alt="Most recent rule hit (Partial excluded) timestamp"
-          />
-          <LabelledInput
-            datafield
-            labelText="Passengers Count from past 500 messages:"
-            inputType="text"
-            name="passengerCount"
-            callback={onChange}
-            readOnly
-            alt="Passengers Count from past 500 messages"
-          />
-          <LabelledInput
-            datafield
-            labelText="Loading/Parsing errors past 500 messages:"
-            inputType="text"
-            name="totalLoadingParsingErrors"
-            callback={onChange}
-            readOnly
-            alt="Loading/Parsing errors past 500 messages"
-          />
+    <Container fluid>
+      <Title title="Loader Statistics"></Title>
+      <br></br>
+      <Container>
+        <Col lg={{ span: 4, offset: 4 }}>
+          <Form data={data} key={key} title="" callback={cb} submitText="Refresh">
+            <LabelledInput
+              datafield
+              labelText="Last message received:"
+              inputType="text"
+              name="lastMessageInSystem"
+              alt="Last message received"
+              readOnly
+              callback={onChange}
+            />
+            <LabelledInput
+              datafield
+              labelText="Last message analyzed:"
+              inputType="text"
+              name="lastMessageAnalyzedByDrools"
+              callback={onChange}
+              readOnly
+              alt="Last message analyzed"
+            />
+            <LabelledInput
+              datafield
+              labelText="Most recent rule hit (Partial excluded) timestamp:"
+              inputType="text"
+              name="mostRecentRuleHit"
+              callback={onChange}
+              readOnly
+              alt="Most recent rule hit (Partial excluded) timestamp"
+            />
+            <LabelledInput
+              datafield
+              labelText="Passengers Count from past 500 messages:"
+              inputType="text"
+              name="passengerCount"
+              callback={onChange}
+              readOnly
+              alt="Passengers Count from past 500 messages"
+            />
+            <LabelledInput
+              datafield
+              labelText="Loading/Parsing errors past 500 messages:"
+              inputType="text"
+              name="totalLoadingParsingErrors"
+              callback={onChange}
+              readOnly
+              alt="Loading/Parsing errors past 500 messages"
+            />
 
-          <LabelledInput
-            datafield
-            labelText="Rule errors last 500 messages:"
-            inputType="text"
-            name="totalRuleErros"
-            callback={onChange}
-            readOnly
-            alt="Rule errors last 500 messages"
-          />
-        </Form>
-      </Col>
+            <LabelledInput
+              datafield
+              labelText="Rule errors last 500 messages:"
+              inputType="text"
+              name="totalRuleErros"
+              callback={onChange}
+              readOnly
+              alt="Rule errors last 500 messages"
+            />
+          </Form>
+        </Col>
+      </Container>
     </Container>
   );
 };

--- a/src/pages/admin/manageUsers/ManageUsers.js
+++ b/src/pages/admin/manageUsers/ManageUsers.js
@@ -94,7 +94,6 @@ const ManageUsers = props => {
 
   const button = (
     <Button
-      block
       variant="ternary"
       className="btn btn-outline-info"
       name={props.name}
@@ -139,7 +138,7 @@ const ManageUsers = props => {
   return (
     <>
       <Container fluid>
-        <Title title="Manage Users" leftChild={button}></Title>
+        <Title title="Manage Users" rightChild={button}></Title>
         <Table
           id="users"
           data={data}

--- a/src/pages/admin/noteTypeCats/NoteTypeCats.js
+++ b/src/pages/admin/noteTypeCats/NoteTypeCats.js
@@ -14,30 +14,28 @@ const NoteTypeCats = ({ name }) => {
     setRefreshKey(refreshKey + 1);
   };
 
+  const addCat = (
+    <Button variant="outline-dark" onClick={() => setShowModal(true)}>
+      Add Category
+    </Button>
+  );
+
   return (
     <Container fluid>
-      <Row>
-        <Col sm={4}>
-          <Title title={name}></Title>
-        </Col>
-        <Col sm={{ span: 4, offset: 4 }}>
-          <Button variant="outline-dark" onClick={() => setShowModal(true)}>
-            Add Note Type Category
-          </Button>
-          <NoteTypeModal
-            show={showModal}
-            onHide={() => setShowModal(false)}
-            refresh={refresh}
-            callback={cb}
-          />
-        </Col>
-      </Row>
+      <Title title={name} rightChild={addCat}></Title>
+      <Row></Row>
       <Table
         service={notetypes.get}
         id="noteTypes"
         key={refreshKey}
         callback={cb}
       ></Table>
+      <NoteTypeModal
+        show={showModal}
+        onHide={() => setShowModal(false)}
+        refresh={refresh}
+        callback={cb}
+      />
     </Container>
   );
 };

--- a/src/pages/admin/settings/Settings.js
+++ b/src/pages/admin/settings/Settings.js
@@ -3,83 +3,88 @@ import { settingsinfo } from "../../../services/serviceWrapper";
 import Form from "../../../components/form/Form";
 import LabelledInput from "../../../components/labelledInput/LabelledInput";
 import { Container, Col } from "react-bootstrap";
+import Title from "../../../components/title/Title";
 
 const Settings = ({ name }) => {
   const onChange = function(result) {};
   const cb = function() {};
 
   return (
-    <Container>
-      <Col lg={{ span: 4, offset: 4 }}>
-        <Form
-          getService={settingsinfo.get}
-          submitService={settingsinfo.put}
-          callback={onChange}
-          title=""
-          action="edit"
-        >
-          <LabelledInput
-            datafield
-            labelText="Matching Threshold"
-            inputType="number"
-            name="matchingThreshold"
-            callback={cb}
-            alt="nothing"
-          />
-          <LabelledInput
-            datafield
-            labelText="Maximum Passenger Query Results"
-            inputType="number"
-            name="maxPassengerQueryResult"
-            callback={cb}
-            alt="nothing"
-          />
-          <LabelledInput
-            datafield
-            labelText="Maximum Flight Query Results"
-            inputType="number"
-            name="maxFlightQueryResult"
-            callback={cb}
-            alt="nothing"
-          />
-          <LabelledInput
-            datafield
-            labelText="Watchlists Matching Flight Range"
-            inputType="number"
-            name="flightRange"
-            callback={cb}
-            alt="nothing"
-          />
-          <LabelledInput
-            datafield
-            labelText="Maximum Rule Hits Allowed Per Run on Rule"
-            inputType="number"
-            name="maxRuleHit"
-            callback={cb}
-            alt="nothing"
-          />
-          <LabelledInput
-            datafield
-            labelText="APIS Only Flag"
-            inputType="select"
-            options={[
-              { value: "TRUE", label: "TRUE" },
-              { value: "FALSE", label: "FALSE" }
-            ]}
-            name="apisOnlyFlag"
-            callback={cb}
-            alt="nothing"
-          />
-          <LabelledInput
-            datafield
-            labelText="APIS Version"
-            inputType="text"
-            name="apisVersion"
-            callback={cb}
-            alt="nothing"
-          />
-        </Form>
-      </Col>
+    <Container fluid>
+      <Title title="Settings"></Title>
+      <br></br>
+      <Container>
+        <Col lg={{ span: 4, offset: 4 }}>
+          <Form
+            getService={settingsinfo.get}
+            submitService={settingsinfo.put}
+            callback={onChange}
+            title=""
+            action="edit"
+          >
+            <LabelledInput
+              datafield
+              labelText="Matching Threshold"
+              inputType="number"
+              name="matchingThreshold"
+              callback={cb}
+              alt="nothing"
+            />
+            <LabelledInput
+              datafield
+              labelText="Maximum Passenger Query Results"
+              inputType="number"
+              name="maxPassengerQueryResult"
+              callback={cb}
+              alt="nothing"
+            />
+            <LabelledInput
+              datafield
+              labelText="Maximum Flight Query Results"
+              inputType="number"
+              name="maxFlightQueryResult"
+              callback={cb}
+              alt="nothing"
+            />
+            <LabelledInput
+              datafield
+              labelText="Watchlists Matching Flight Range"
+              inputType="number"
+              name="flightRange"
+              callback={cb}
+              alt="nothing"
+            />
+            <LabelledInput
+              datafield
+              labelText="Maximum Rule Hits Allowed Per Run on Rule"
+              inputType="number"
+              name="maxRuleHit"
+              callback={cb}
+              alt="nothing"
+            />
+            <LabelledInput
+              datafield
+              labelText="APIS Only Flag"
+              inputType="select"
+              options={[
+                { value: "TRUE", label: "TRUE" },
+                { value: "FALSE", label: "FALSE" }
+              ]}
+              name="apisOnlyFlag"
+              callback={cb}
+              alt="nothing"
+            />
+            <LabelledInput
+              datafield
+              labelText="APIS Version"
+              inputType="text"
+              name="apisVersion"
+              callback={cb}
+              alt="nothing"
+            />
+          </Form>
+        </Col>
+      </Container>
     </Container>
   );
 };

--- a/src/pages/admin/watchlistCats/WatchlistCats.js
+++ b/src/pages/admin/watchlistCats/WatchlistCats.js
@@ -16,30 +16,27 @@ const WatchlistCats = ({ name }) => {
     setRefreshKey(refreshKey + 1);
   };
 
+  const cats = (
+    <Button variant="outline-dark" onClick={() => setShowModal(true)}>
+      Add Category
+    </Button>
+  );
+
   return (
     <Container fluid>
-      <Row>
-        <Col sm={4}>
-          <Title title={name}></Title>
-        </Col>
-        <Col sm={{ span: 4, offset: 4 }}>
-          <Button variant="outline-dark" onClick={() => setShowModal(true)}>
-            Add to Watchlist
-          </Button>
-          <WatchlistModal
-            show={showModal}
-            onHide={() => setShowModal(false)}
-            refresh={refresh}
-            callback={cb}
-          />
-        </Col>
-      </Row>
+      <Title title={name} rightChild={cats}></Title>
       <Table
         service={watchlistcats.get}
         id="Watchlist Category"
         key={refreshKey}
         callback={cb}
       ></Table>
+      <WatchlistModal
+        show={showModal}
+        onHide={() => setShowModal(false)}
+        refresh={refresh}
+        callback={cb}
+      />
     </Container>
   );
 };

--- a/src/pages/tools/queryrules/Queries.js
+++ b/src/pages/tools/queryrules/Queries.js
@@ -27,7 +27,6 @@ const Queries = props => {
 
   const button = (
     <Button
-      block
       variant="ternary"
       className="btn btn-outline-info"
       onClick={() => launchModal(0)}

--- a/src/pages/tools/queryrules/Rules.js
+++ b/src/pages/tools/queryrules/Rules.js
@@ -156,7 +156,6 @@ const Rules = props => {
 
   const button = (
     <Button
-      block
       variant="ternary"
       className="btn btn-outline-info"
       name={props.name}

--- a/src/pages/tools/watchlist/Watchlist.js
+++ b/src/pages/tools/watchlist/Watchlist.js
@@ -28,7 +28,6 @@ const Watchlist = props => {
 
   const button = (
     <Button
-      block
       variant="ternary"
       className="btn btn-outline-info"
       name={props.name}


### PR DESCRIPTION
New layout for the Header component and Admin base page to remove the tab bar. Admin now shows as a dropdown menu in the header like Tools does. Fixes #14 .

includes various layout adjustments like adding titles to Admin child pages and pushing action controls into the page's Title component to reduce clutter.

**!!This impacts all pages with a Title component, pls view all pages when testing!!**

further tweaks will be defined in future tickets.