### PR TITLE
init bundle reorg. Must run yarn install for new deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     }
   },
   "dependencies": {
+    "@loadable/component": "^5.13.1",
     "@reach/router": "^1.3.3",
     "axios": "^0.19.0",
     "bootstrap": "^4.4.1",

--- a/src/App.js
+++ b/src/App.js
@@ -1,8 +1,8 @@
 import React, { Suspense } from "react";
 import { Router, Redirect, navigate } from "@reach/router";
 import IdleTimer from "react-idle-timer";
-// import logo from './logo.svg';
-import Login from "./pages/login/Login";
+import loadable from "@loadable/component";
+
 import Flights from "./pages/flights/Flights";
 import PriorityVetting from "./pages/vetting/Vetting";
 import Home from "./pages/home/Home";
@@ -16,21 +16,8 @@ import APIS from "./pages/paxDetail/apis/APIS";
 import PNR from "./pages/paxDetail/pnr/PNR";
 import FlightHistory from "./pages/paxDetail/flightHistory/FlightHistory";
 import FlightPax from "./pages/flightPax/FlightPax";
-import Admin from "./pages/admin/Admin";
-import ManageUser from "./pages/admin/manageUsers/ManageUsers";
 
-import FileDownload from "./pages/admin/fileDownload/FileDownload";
-import AuditLog from "./pages/admin/auditLog/AuditLog";
-import ErrorLog from "./pages/admin/errorLog/ErrorLog";
-import CodeEditor from "./pages/admin/codeEditor/CodeEditor";
-import Airports from "./pages/admin/codeEditor/airport/Airports";
-import Carriers from "./pages/admin/codeEditor/carrier/Carriers";
-import Countries from "./pages/admin/codeEditor/country/Countries";
-import LoaderStats from "./pages/admin/loaderStats/LoaderStats";
-import Settings from "./pages/admin/settings/Settings";
-import WatchlistCats from "./pages/admin/watchlistCats/WatchlistCats";
-import NoteTypeCats from "./pages/admin/noteTypeCats/NoteTypeCats";
-import QueryRules from "./pages/tools/queryrules/Rules";
+import Rules from "./pages/tools/queryrules/Rules";
 import Queries from "./pages/tools/queryrules/Queries";
 import QRDetails from "./pages/tools/queryrules/QRDetails";
 import Neo4J from "./pages/tools/neo4J/Neo4J";
@@ -48,15 +35,77 @@ import RoleAuthenticator from "./context/roleAuthenticator/RoleAuthenticator";
 import UserProvider from "./context/user/UserContext";
 
 import { ROLE, TIME } from "./utils/constants";
-import ChangePassword from "./pages/admin/manageUsers/changePassword/ChangePassword";
-import SignUp from "./pages/signUp/SignUp";
-import SignUpRequests from "./pages/admin/signUpRequests/SignUpRequests";
-import ResetPassword from "./pages/admin/manageUsers/changePassword/ResetPassword";
-import ForgotPassword from "./pages/admin/manageUsers/changePassword/ForgotPassword";
 
-//Split Link Analysis (Graph component, d3, jquery deps) into a separate bundle
-const LinkAnalysis = React.lazy(() =>
-  import("./pages/paxDetail/linkAnalysis/LinkAnalysis")
+//login bundle
+const Login = loadable(() =>
+  import(/* webpackChunkName: "unauthed" */ "./pages/login/Login")
+);
+const SignUp = loadable(() =>
+  import(/* webpackChunkName: "unauthed" */ "./pages/signUp/SignUp")
+);
+const ResetPassword = loadable(() =>
+  import(
+    /* webpackChunkName: "unauthed" */ "./pages/admin/manageUsers/changePassword/ResetPassword"
+  )
+);
+const ForgotPassword = loadable(() =>
+  import(
+    /* webpackChunkName: "unauthed" */ "./pages/admin/manageUsers/changePassword/ForgotPassword"
+  )
+);
+
+//Link Analysis bundle
+const LinkAnalysis = loadable(() =>
+  import(/* webpackChunkName: "vaquita" */ "./pages/paxDetail/linkAnalysis/LinkAnalysis")
+);
+
+//Admin bundle imports
+const Admin = loadable(() =>
+  import(/* webpackChunkName: "admin" */ "./pages/admin/Admin")
+);
+const ManageUser = loadable(() =>
+  import(/* webpackChunkName: "admin" */ "./pages/admin/manageUsers/ManageUsers")
+);
+const FileDownload = loadable(() =>
+  import(/* webpackChunkName: "admin" */ "./pages/admin/fileDownload/FileDownload")
+);
+const AuditLog = loadable(() =>
+  import(/* webpackChunkName: "admin" */ "./pages/admin/auditLog/AuditLog")
+);
+const ErrorLog = loadable(() =>
+  import(/* webpackChunkName: "admin" */ "./pages/admin/errorLog/ErrorLog")
+);
+const CodeEditor = loadable(() =>
+  import(/* webpackChunkName: "admin" */ "./pages/admin/codeEditor/CodeEditor")
+);
+const Airports = loadable(() =>
+  import(/* webpackChunkName: "admin" */ "./pages/admin/codeEditor/airport/Airports")
+);
+const Carriers = loadable(() =>
+  import(/* webpackChunkName: "admin" */ "./pages/admin/codeEditor/carrier/Carriers")
+);
+const Countries = loadable(() =>
+  import(/* webpackChunkName: "admin" */ "./pages/admin/codeEditor/country/Countries")
+);
+const LoaderStats = loadable(() =>
+  import(/* webpackChunkName: "admin" */ "./pages/admin/loaderStats/LoaderStats")
+);
+const Settings = loadable(() =>
+  import(/* webpackChunkName: "admin" */ "./pages/admin/settings/Settings")
+);
+const WatchlistCats = loadable(() =>
+  import(/* webpackChunkName: "admin" */ "./pages/admin/watchlistCats/WatchlistCats")
+);
+const NoteTypeCats = loadable(() =>
+  import(/* webpackChunkName: "admin" */ "./pages/admin/noteTypeCats/NoteTypeCats")
+);
+const ChangePassword = loadable(() =>
+  import(
+    /* webpackChunkName: "admin" */ "./pages/admin/manageUsers/changePassword/ChangePassword"
+  )
+);
+const SignUpRequests = loadable(() =>
+  import(/* webpackChunkName: "admin" */ "./pages/admin/signUpRequests/SignUpRequests")
 );
 
 export default class App extends React.Component {
@@ -95,12 +144,6 @@ export default class App extends React.Component {
   }
 
   render() {
-    // if (this.state.redirect) {
-    //   this.setState({ redirect: false });
-    //   // logout and ...
-    //   return <Redirect to="/login" />;
-    // }
-
     const UNAUTHED = <PageUnauthorized path="pageUnauthorized"></PageUnauthorized>;
 
     return (
@@ -154,12 +197,12 @@ export default class App extends React.Component {
                     <Home path="/gtas">
                       <Page404 default></Page404>
                       <Redirect from="/gtas" to="/gtas/flights" noThrow />
-                      <Dashboard path="dashboard"></Dashboard>
                       <Flights path="flights"></Flights>
                       <FlightPax path="flightpax/:id"></FlightPax>
                       <PriorityVetting path="vetting"></PriorityVetting>
-                      <QueryRules path="tools/rules"></QueryRules>
-                      <QueryRules path="tools/rules/:mode"></QueryRules>
+                      <Dashboard path="dashboard"></Dashboard>
+                      <Rules path="tools/rules"></Rules>
+                      <Rules path="tools/rules/:mode"></Rules>
                       <Queries path="tools/queries"></Queries>
                       <QRDetails path="tools/qrdetails"></QRDetails>
                       <Neo4J path="tools/neo4j"></Neo4J>
@@ -210,11 +253,7 @@ export default class App extends React.Component {
                         <APIS path="apis"></APIS>
                         <PNR path="pnr"></PNR>
                         <FlightHistory path="flighthistory"></FlightHistory>
-                        <ErrorBoundary>
-                          <Suspense fallback={<Loading></Loading>}>
-                            <LinkAnalysis path="linkanalysis"></LinkAnalysis>
-                          </Suspense>
-                        </ErrorBoundary>
+                        <LinkAnalysis path="linkanalysis"></LinkAnalysis>
                       </PaxDetail>
                       <PageUnauthorized path="pageUnauthorized"></PageUnauthorized>
                     </Home>

--- a/src/App.js
+++ b/src/App.js
@@ -3,31 +3,10 @@ import { Router, Redirect, navigate } from "@reach/router";
 import IdleTimer from "react-idle-timer";
 import loadable from "@loadable/component";
 
-import Flights from "./pages/flights/Flights";
-import PriorityVetting from "./pages/vetting/Vetting";
-import Home from "./pages/home/Home";
 import "bootstrap/dist/css/bootstrap.min.css";
 import "font-awesome/css/font-awesome.min.css";
 import "./App.css";
-import Dashboard from "./pages/dashboard/Dashboard";
-import PaxDetail from "./pages/paxDetail/PaxDetail";
-import Summary from "./pages/paxDetail/summary/Summary";
-import APIS from "./pages/paxDetail/apis/APIS";
-import PNR from "./pages/paxDetail/pnr/PNR";
-import FlightHistory from "./pages/paxDetail/flightHistory/FlightHistory";
-import FlightPax from "./pages/flightPax/FlightPax";
-import LinkAnalysis from "./pages/paxDetail/linkAnalysis/LinkAnalysis";
 
-import Rules from "./pages/tools/queryrules/Rules";
-import Queries from "./pages/tools/queryrules/Queries";
-import QRDetails from "./pages/tools/queryrules/QRDetails";
-import Neo4J from "./pages/tools/neo4J/Neo4J";
-import Watchlist from "./pages/tools/watchlist/Watchlist";
-import About from "./pages/tools/about/About";
-import GModal from "./components/modal/GModal";
-
-import Page404 from "./pages/page404/Page404";
-import PageUnauthorized from "./pages/pageUnauthorized/PageUnauthorized";
 import ErrorBoundary from "./components/errorBoundary/ErrorBoundary";
 import Loading from "./components/loading/Loading";
 
@@ -38,17 +17,68 @@ import UserProvider from "./context/user/UserContext";
 import { ROLE, TIME } from "./utils/constants";
 
 //login bundle
-const Login = loadable(() =>
-  import(/* webpackChunkName: "unauthed" */ "./pages/login/Login")
+import Login from "./pages/login/Login";
+import SignUp from "./pages/signUp/SignUp";
+import ResetPassword from "./pages/login/ResetPassword";
+import ForgotPassword from "./pages/login/ForgotPassword";
+
+const Flights = loadable(() =>
+  import(/* webpackChunkName: "authed" */ "./pages/flights/Flights")
 );
-const SignUp = loadable(() =>
-  import(/* webpackChunkName: "unauthed" */ "./pages/signUp/SignUp")
+const PriorityVetting = loadable(() =>
+  import(/* webpackChunkName: "authed" */ "./pages/vetting/Vetting")
 );
-const ResetPassword = loadable(() =>
-  import(/* webpackChunkName: "unauthed" */ "./pages/login/ResetPassword")
+const Home = loadable(() => import(/* webpackChunkName: "authed" */ "./pages/home/Home"));
+const Dashboard = loadable(() =>
+  import(/* webpackChunkName: "authed" */ "./pages/dashboard/Dashboard")
 );
-const ForgotPassword = loadable(() =>
-  import(/* webpackChunkName: "unauthed" */ "./pages/login/ForgotPassword")
+const PaxDetail = loadable(() =>
+  import(/* webpackChunkName: "authed" */ "./pages/paxDetail/PaxDetail")
+);
+const Summary = loadable(() =>
+  import(/* webpackChunkName: "authed" */ "./pages/paxDetail/summary/Summary")
+);
+const APIS = loadable(() =>
+  import(/* webpackChunkName: "authed" */ "./pages/paxDetail/apis/APIS")
+);
+const PNR = loadable(() =>
+  import(/* webpackChunkName: "authed" */ "./pages/paxDetail/pnr/PNR")
+);
+const FlightHistory = loadable(() =>
+  import(/* webpackChunkName: "authed" */ "./pages/paxDetail/flightHistory/FlightHistory")
+);
+const FlightPax = loadable(() =>
+  import(/* webpackChunkName: "authed" */ "./pages/flightPax/FlightPax")
+);
+const LinkAnalysis = loadable(() =>
+  import(/* webpackChunkName: "authed" */ "./pages/paxDetail/linkAnalysis/LinkAnalysis")
+);
+const Rules = loadable(() =>
+  import(/* webpackChunkName: "authed" */ "./pages/tools/queryrules/Rules")
+);
+const Queries = loadable(() =>
+  import(/* webpackChunkName: "authed" */ "./pages/tools/queryrules/Queries")
+);
+const QRDetails = loadable(() =>
+  import(/* webpackChunkName: "authed" */ "./pages/tools/queryrules/QRDetails")
+);
+const Neo4J = loadable(() =>
+  import(/* webpackChunkName: "authed" */ "./pages/tools/neo4J/Neo4J")
+);
+const Watchlist = loadable(() =>
+  import(/* webpackChunkName: "authed" */ "./pages/tools/watchlist/Watchlist")
+);
+const About = loadable(() =>
+  import(/* webpackChunkName: "authed" */ "./pages/tools/about/About")
+);
+const GModal = loadable(() =>
+  import(/* webpackChunkName: "authed" */ "./components/modal/GModal")
+);
+const Page404 = loadable(() =>
+  import(/* webpackChunkName: "authed" */ "./pages/page404/Page404")
+);
+const PageUnauthorized = loadable(() =>
+  import(/* webpackChunkName: "authed" */ "./pages/pageUnauthorized/PageUnauthorized")
 );
 
 //Admin bundle imports

--- a/src/App.js
+++ b/src/App.js
@@ -16,6 +16,7 @@ import APIS from "./pages/paxDetail/apis/APIS";
 import PNR from "./pages/paxDetail/pnr/PNR";
 import FlightHistory from "./pages/paxDetail/flightHistory/FlightHistory";
 import FlightPax from "./pages/flightPax/FlightPax";
+import LinkAnalysis from "./pages/paxDetail/linkAnalysis/LinkAnalysis";
 
 import Rules from "./pages/tools/queryrules/Rules";
 import Queries from "./pages/tools/queryrules/Queries";
@@ -44,19 +45,10 @@ const SignUp = loadable(() =>
   import(/* webpackChunkName: "unauthed" */ "./pages/signUp/SignUp")
 );
 const ResetPassword = loadable(() =>
-  import(
-    /* webpackChunkName: "unauthed" */ "./pages/admin/manageUsers/changePassword/ResetPassword"
-  )
+  import(/* webpackChunkName: "unauthed" */ "./pages/login/ResetPassword")
 );
 const ForgotPassword = loadable(() =>
-  import(
-    /* webpackChunkName: "unauthed" */ "./pages/admin/manageUsers/changePassword/ForgotPassword"
-  )
-);
-
-//Link Analysis bundle
-const LinkAnalysis = loadable(() =>
-  import(/* webpackChunkName: "vaquita" */ "./pages/paxDetail/linkAnalysis/LinkAnalysis")
+  import(/* webpackChunkName: "unauthed" */ "./pages/login/ForgotPassword")
 );
 
 //Admin bundle imports

--- a/src/components/graph/Graph.js
+++ b/src/components/graph/Graph.js
@@ -1,11 +1,13 @@
-import React, { useState } from "react";
+import React from "react";
+import loadable from "@loadable/component";
 import "../../services/configService";
 import { cypher, cypherAuth } from "../../services/serviceWrapper";
-import * as d3 from "d3";
 import { provider, paxRelations, saves, palette } from "./structure";
 import "./Graph.css";
 import "../../../node_modules/vaquita/css/vaquita-svg.css";
-const vaquita = require("vaquita");
+
+const select = loadable.lib(() => import("d3-selection"));
+const vaquita = loadable.lib(() => import("vaquita"));
 
 class Graph extends React.Component {
   constructor(props) {
@@ -154,9 +156,8 @@ class Graph extends React.Component {
   onClickSavedGraph = function(id) {
     // Update Graph title:
     if (!id) {
-      d3.select("#save-header").text(
-        d3
-          .select(this)
+      select("#save-header").text(
+        select(this)
           .select(".ppt-label")
           .text()
       );

--- a/src/components/graph/Graph.js
+++ b/src/components/graph/Graph.js
@@ -1,13 +1,12 @@
 import React from "react";
-import loadable from "@loadable/component";
 import "../../services/configService";
 import { cypher, cypherAuth } from "../../services/serviceWrapper";
 import { provider, paxRelations, saves, palette } from "./structure";
 import "./Graph.css";
 import "../../../node_modules/vaquita/css/vaquita-svg.css";
+import * as d3 from "d3";
 
-const select = loadable.lib(() => import("d3-selection"));
-const vaquita = loadable.lib(() => import("vaquita"));
+const vaquita = require("vaquita");
 
 class Graph extends React.Component {
   constructor(props) {
@@ -156,8 +155,9 @@ class Graph extends React.Component {
   onClickSavedGraph = function(id) {
     // Update Graph title:
     if (!id) {
-      select("#save-header").text(
-        select(this)
+      d3.select("#save-header").text(
+        d3
+          .select(this)
           .select(".ppt-label")
           .text()
       );

--- a/src/pages/login/ForgotPassword.js
+++ b/src/pages/login/ForgotPassword.js
@@ -1,10 +1,10 @@
 import React, { useState } from "react";
-import Form from "../../../../components/form/Form";
-import LabelledInput from "../../../../components/labelledInput/LabelledInput";
-import { forgotPassword } from "../../../../services/serviceWrapper";
+import Form from "../../components/form/Form";
+import LabelledInput from "../../components/labelledInput/LabelledInput";
+import { forgotPassword } from "../../services/serviceWrapper";
 import { Container, Alert } from "react-bootstrap";
-import Title from "../../../../components/title/Title";
-import { hasData } from "../../../../utils/utils";
+import Title from "../../components/title/Title";
+import { hasData } from "../../utils/utils";
 import { Link } from "@reach/router";
 
 const ForgotPassword = props => {

--- a/src/pages/login/ResetPassword.js
+++ b/src/pages/login/ResetPassword.js
@@ -1,10 +1,10 @@
 import React, { useState, useEffect } from "react";
-import Form from "../../../../components/form/Form";
-import LabelledInput from "../../../../components/labelledInput/LabelledInput";
-import { resetPassword } from "../../../../services/serviceWrapper";
+import Form from "../../components/form/Form";
+import LabelledInput from "../../components/labelledInput/LabelledInput";
+import { resetPassword } from "../../services/serviceWrapper";
 import { Container, Alert } from "react-bootstrap";
-import Title from "../../../../components/title/Title";
-import { hasData } from "../../../../utils/utils";
+import Title from "../../components/title/Title";
+import { hasData } from "../../utils/utils";
 import { useParams, Link } from "@reach/router";
 
 const ResetPassword = props => {

--- a/src/pages/tools/queryrules/Rules.js
+++ b/src/pages/tools/queryrules/Rules.js
@@ -167,7 +167,7 @@ const Rules = props => {
     }
 
     fetchTableData();
-  }, [tab]);
+  }, [tab, endpoint]);
 
   const tabs = (
     <Tabs defaultActiveKey={RULETAB.MY} id="qrTabs">

--- a/yarn.lock
+++ b/yarn.lock
@@ -1081,6 +1081,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.7.7":
+  version "7.11.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
+  integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4", "@babel/template@^7.4.0", "@babel/template@^7.8.6":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
@@ -1388,6 +1395,15 @@
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
+
+"@loadable/component@^5.13.1":
+  version "5.13.1"
+  resolved "https://registry.yarnpkg.com/@loadable/component/-/component-5.13.1.tgz#b7650a76f9cc1cccf17f79265dc05b9e62daaaa2"
+  integrity sha512-qTNfTv5bVfb9eTKNUOMzPweRnxzNaxCmLZEsFEMn+kxpd86iXae+IpibXFJlnb052Q4fVkcWM2tvmWLc/+HzLg==
+  dependencies:
+    "@babel/runtime" "^7.7.7"
+    hoist-non-react-statics "^3.3.1"
+    react-is "^16.12.0"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -6245,6 +6261,13 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
+hoist-non-react-statics@^3.3.1:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
+
 hosted-git-info@^2.1.4:
   version "2.8.8"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.8.tgz#7539bd4bc1e0e0a895815a2e0262420b12858488"
@@ -10736,7 +10759,7 @@ react-input-autosize@^2.2.2:
   dependencies:
     prop-types "^15.5.8"
 
-react-is@^16.3.2, react-is@^16.8.1, react-is@^16.8.4:
+react-is@^16.12.0, react-is@^16.3.2, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==


### PR DESCRIPTION
Not a functional change, just breaks the code out logically into separate bundles to minimize the prod footprint where possible. 

To test:
Run 'yarn install' for the new deps
Run 'yarn build' to generate prod resources
Run 'yarn analyze' to view the source tree and verify the content of the bundles OR view the bundle files at root/build/static/js, 

verify that the js files include bundles with names beginning **admin**, **unauthed**, and **main**. Deps have bundles beginning with a number, the first (shd begin with "4") contains all 3rd party dependencies not explicitly split into another bundle. Bundle "5" should contain the vaquita dep and its peers jquery and some d3 modules. Bundle "6" will have d3-selection.

