### PR TITLE
Notification Users modal - minor layout misc

### DIFF
--- a/src/pages/admin/manageUsers/ManageUsers.scss
+++ b/src/pages/admin/manageUsers/ManageUsers.scss
@@ -29,6 +29,7 @@
   orphans: 1;
   widows: 1;
   margin-bottom: 10px;
+  width: -webkit-fill-available;
 }
 
 .um-checkbox > div > .row > div > .form-inline {

--- a/src/pages/paxDetail/evenNotesModal/EventNotesModal.js
+++ b/src/pages/paxDetail/evenNotesModal/EventNotesModal.js
@@ -39,7 +39,6 @@ const EventNotesModal = props => {
         show={show}
         onHide={handleClose}
         size="md"
-        backdrop="static"
         aria-labelledby="contained-modal-title-vcenter"
         centered
       >

--- a/src/pages/paxDetail/notification/Notification.js
+++ b/src/pages/paxDetail/notification/Notification.js
@@ -48,7 +48,6 @@ const Notification = props => {
         show={show}
         onHide={handleClose}
         size="md"
-        backdrop="static"
         aria-labelledby="contained-modal-title-vcenter"
         centered
       >

--- a/src/pages/paxDetail/notification/Notification.scss
+++ b/src/pages/paxDetail/notification/Notification.scss
@@ -8,6 +8,7 @@
   orphans: 1;
   widows: 1;
   margin-bottom: 10px;
+  width: -webkit-fill-available;
 }
 
 .notify-checkbox .row .form-inline {


### PR DESCRIPTION
Issue is that the modal wasn't letting you close it by clicking outside it (which is a no-no), and also fixed a minor layout issue where the user list was spilling outside the modal boundary.

![notifyUsers](https://user-images.githubusercontent.com/49160279/91895578-7c54b680-ec65-11ea-81d4-a512c51752ff.JPG)
