### PR TITLE
Fix/tablespinner

### DIFF
--- a/src/components/loading/Loading.css
+++ b/src/components/loading/Loading.css
@@ -1,0 +1,7 @@
+.loading {
+  margin-top: 20px;
+  margin-bottom: 20px;
+  align-self: center !important;
+  color: #0077c8;
+  text-align: center;
+}

--- a/src/components/loading/Loading.js
+++ b/src/components/loading/Loading.js
@@ -1,9 +1,10 @@
 import React from "react";
+import "./Loading.css";
 
 export default function Loading() {
   return (
-    <div className="col-6 align-self-center offset-5">
-      <i className="fa fa-spinner fa-pulse fa-3x fa-fw"></i>
+    <div className="loading">
+      <i className="fa fa-spinner fa-pulse fa-4x fa-fw"></i>
       <span className="sr-only">Loading...</span>
     </div>
   );

--- a/src/components/table/Table.js
+++ b/src/components/table/Table.js
@@ -25,8 +25,8 @@ const Table = props => {
 
   useEffect(() => {
     validateProps();
-    if (!Array.isArray(data)) getData();
-    else parseData(data);
+    if (!Array.isArray(props.data)) getData();
+    else parseData(props.data);
   }, []);
 
   function ColumnFilter({ column: { filterValue, setFilter } }) {

--- a/src/components/table/Table.js
+++ b/src/components/table/Table.js
@@ -1,27 +1,32 @@
 import React, { useEffect, useState, Fragment } from "react";
 import PropTypes from "prop-types";
-import { hasData, titleCase, asArray, altObj, isObject } from "../../utils/utils";
+import { hasData, titleCase, asArray, altObj } from "../../utils/utils";
 import { useTable, usePagination, useSortBy, useFilters } from "react-table";
 import { navigate } from "@reach/router";
 // import { withTranslation } from 'react-i18next';
 // import Xl8 from '../xl8/Xl8';
-import { Table as RBTable, Col, Pagination } from "react-bootstrap";
+import Loading from "../../components/loading/Loading";
+import { Table as RBTable, Pagination } from "react-bootstrap";
 import "./Table.css";
 
 //Will auto-populate with data retrieved from the given uri
 //Attempts to format the header from the column names, but can be passed a header array instead.
 
 const Table = props => {
-  const [data, setData] = useState(props.data || []);
+  const initData = [];
+
+  const [data, setData] = useState(props.data || initData);
   const [header, setHeader] = useState(props.header || []);
   const [columns, setColumns] = useState([]);
   const [rowcount, setRowcount] = useState("");
   const stateVals = props.hasOwnProperty("stateVals") ? altObj(props.stateVals()) : {};
   const [displayColumnFilter, setDisplayColumnFilter] = useState(false);
+  const showPending = props.showPending;
+
   useEffect(() => {
     validateProps();
-    if (!Array.isArray(props.data)) getData();
-    else parseData(props.data);
+    if (!Array.isArray(data)) getData();
+    else parseData(data);
   }, []);
 
   function ColumnFilter({ column: { filterValue, setFilter } }) {
@@ -133,6 +138,7 @@ const Table = props => {
     return (
       <>
         <div className="table-main">
+          {showPending && data === initData && <Loading></Loading>}
           <RBTable {...getTableProps()} striped bordered hover>
             <thead>
               {headerGroups.map((headerGroup, index) => {
@@ -289,6 +295,8 @@ const Table = props => {
   };
 
   const parseData = data => {
+    if (showPending && data === initData) return;
+
     const noDataFound = "No Data Found";
     let noDataObj = [{}];
     noDataObj[0][props.id] = noDataFound;
@@ -339,13 +347,13 @@ const Table = props => {
     setColumns(columns);
 
     //exclude the No-Data-Found row from the count
-    if (dataArray.length === 1 && dataArray[0][props.id] == noDataFound) setRowcount(0);
+    if (dataArray.length === 1 && dataArray[0][props.id] === noDataFound) setRowcount(0);
     else setRowcount(dataArray.length);
   };
 
   const getData = (params = null) => {
     if (!hasData(props.service)) {
-      parseData({});
+      parseData([]);
       return;
     }
     props
@@ -389,6 +397,7 @@ Table.propTypes = {
   style: PropTypes.string,
   stateCb: PropTypes.func,
   stateVals: PropTypes.func,
+  showPending: PropTypes.bool,
   ignoredFields: PropTypes.arrayOf(PropTypes.string),
   enableColumnFilter: PropTypes.bool
 };

--- a/src/pages/admin/manageUsers/ManageUsers.js
+++ b/src/pages/admin/manageUsers/ManageUsers.js
@@ -12,7 +12,7 @@ import { navigate } from "@reach/router";
 import Confirm from "../../../components/confirmationModal/Confirm";
 
 const ManageUsers = props => {
-  const [data, setData] = useState([]);
+  const [data, setData] = useState(undefined);
   const [showModal, setShowModal] = useState(false);
   const [refreshKey, setRefreshKey] = useState(1);
   const [isEditModal, setIsEditModal] = useState(false);
@@ -186,6 +186,7 @@ const ManageUsers = props => {
           key={refreshKey}
           header={headers}
           enableColumnFilter={true}
+          showPending={true}
         ></Table>
         <UserModal
           show={showModal}

--- a/src/pages/admin/signUpRequests/SignUpRequests.js
+++ b/src/pages/admin/signUpRequests/SignUpRequests.js
@@ -10,7 +10,7 @@ import LabelledInput from "../../../components/labelledInput/LabelledInput";
 import { hasData } from "../../../utils/utils";
 
 const SignUpRequests = () => {
-  const [data, setData] = useState([]);
+  const [data, setData] = useState();
   const [refreshKey, setRefreshKey] = useState(0);
   const [fetchData, setFetchData] = useState(0);
   const [show, setShow] = useState(false);
@@ -164,6 +164,7 @@ const SignUpRequests = () => {
           id="SigUpRequest"
           callback={cb}
           key={refreshKey}
+          showPending={true}
         ></Table>
       </Main>
     </>

--- a/src/pages/tools/queryrules/QRDetails.js
+++ b/src/pages/tools/queryrules/QRDetails.js
@@ -8,7 +8,7 @@ import { asArray, getAge, alt, localeDateOnly } from "../../../utils/utils";
 
 const QRDetails = props => {
   const cb = function(result) {};
-  const [data, setData] = useState([]);
+  const [data, setData] = useState();
   const [key, setKey] = useState(0);
 
   const parseData = data => {
@@ -72,6 +72,7 @@ const QRDetails = props => {
         header={headers}
         id="Query Details"
         callback={cb}
+        showPending={true}
         key={key}
       ></Table>
     </Container>

--- a/src/pages/tools/queryrules/Rules.js
+++ b/src/pages/tools/queryrules/Rules.js
@@ -205,6 +205,7 @@ const Rules = props => {
         id="Rules"
         callback={cb}
         header={header}
+        showPending={true}
         key={`table-${tablekey}`}
       ></Table>
       {showModal && (


### PR DESCRIPTION
Adds a spinner to the table to prevent showing the "No data found" message until all data is received.

Doesn't show if the table receives new data quickly but requires time to parse and display the data, fyi, but it does at least prevent the misleading "No data" message.

Added it to the query details, rules, and a few other pages, but not globally yet.

To use it, you need to pass the initial dataset to the Table component as undefined (not empty array) and set the showPending property to true.

<!---
@huboard:{"milestone_order":0.9876802620219977}
-->
