### PR TITLE
prevent vaquita dep from updating in background

### DIFF
--- a/src/components/graph/Graph.js
+++ b/src/components/graph/Graph.js
@@ -100,7 +100,6 @@ class Graph extends React.Component {
       origin: this.pax1.embarkation,
       destination: this.pax1.debarkation,
       vaquita: vaquita,
-      // thisPaxFlight: thisPaxFlight,
       paxRelations: paxRelations(
         this.pax1.flightIdTag,
         this.pax1.carrier + this.pax1.flightNumber
@@ -123,6 +122,12 @@ class Graph extends React.Component {
 
   shouldComponentUpdate() {
     return false;
+  }
+
+  componentWillUnmount() {
+    // prevent jquery from attempting updates on the resize event after the component is unmounted
+    // this deregisters the vaquita listener on the window on unmount
+    window.removeEventListener("resize", vaquita.graph.centerRootNode, false);
   }
 
   // documentPath = function() {

--- a/src/pages/paxDetail/PaxDetail.js
+++ b/src/pages/paxDetail/PaxDetail.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import Tabs from "../../components/tabs/Tabs";
-import { Button, Navbar, Nav } from "react-bootstrap";
+import { Navbar, Nav } from "react-bootstrap";
 import "./PaxDetail.scss";
 import PaxInfo from "../../components/paxInfo/PaxInfo";
 import SideNav from "../../components/sidenav/SideNav";


### PR DESCRIPTION
Link analysis was making background calls on window resize event even when the page was unmounted. Issue was that the vaquita dependency (jquery) had registered a listener for the resize event that was retained in memory, and which keeps the api in memory when not required. If connected to neo4j, it would continue to make calls to update and redraw itself on each resize event, which is problematic.

Fixed it by capturing the event that triggered the fetch and deregistering it. Somebody owes me a cupcake.

<!---
@huboard:{"milestone_order":0.9876779471536175}
-->
