### PR TITLE
Fix/tablespinner2

### DIFF
--- a/src/components/table/Table.js
+++ b/src/components/table/Table.js
@@ -13,24 +13,30 @@ import "./Table.css";
 //Attempts to format the header from the column names, but can be passed a header array instead.
 
 const Table = props => {
-  const alternateData = [];
-  const initData = props.data || alternateData;
+  // to show the spinner when data is loading (either from within Table or at the caller), we assume:
+  // props.data === undefined ==> data is pending
+  // props.data === []        ==> fetch is complete, data has no rows
+  // hasData(props.data)      ==> fetch is complete, data has rows
 
-  const [data, setData] = useState(initData);
+  const [data, setData] = useState(props.data || undefined);
   const [header, setHeader] = useState(props.header || []);
   const [columns, setColumns] = useState([]);
   const [rowcount, setRowcount] = useState("");
   const stateVals = props.hasOwnProperty("stateVals") ? altObj(props.stateVals()) : {};
   const [displayColumnFilter, setDisplayColumnFilter] = useState(false);
-  const [showPending, setShowPending] = useState(props.showPending || false);
+  const [showPending, setShowPending] = useState(false);
 
   useEffect(() => {
     validateProps();
-    if (hasData(props.service)) {
-      setShowPending(true);
-      getData();
-    } else parseData(initData);
+
+    if (hasData(props.data)) parseData(props.data);
+    else if (hasData(props.service)) getData();
+    else parseData();
   }, []);
+
+  useEffect(() => {
+    parseData(data);
+  }, [data]);
 
   function ColumnFilter({ column: { filterValue, setFilter } }) {
     return (
@@ -141,7 +147,7 @@ const Table = props => {
     return (
       <>
         <div className="table-main">
-          {showPending && data === alternateData && <Loading></Loading>}
+          {showPending && <Loading></Loading>}
           <RBTable {...getTableProps()} striped bordered hover>
             <thead>
               {headerGroups.map((headerGroup, index) => {
@@ -298,9 +304,12 @@ const Table = props => {
   };
 
   const parseData = data => {
-    console.log("show pending ???", showPending && data === alternateData);
-    if (showPending && data === alternateData) return;
+    if (!data) {
+      setShowPending(true);
+      return;
+    }
 
+    setShowPending(false);
     const noDataFound = "No Data Found";
     let noDataObj = [{}];
     noDataObj[0][props.id] = noDataFound;
@@ -356,18 +365,21 @@ const Table = props => {
   };
 
   const getData = (params = null) => {
+    setShowPending(true);
     if (!hasData(props.service)) {
-      parseData([]);
+      parseData();
       return;
     }
     props
       .service(params)
       .then(response => {
         parseData(response);
+        setShowPending(false);
       })
       .catch(error => {
         console.log(error);
         parseData([]);
+        setShowPending(false);
       });
   };
 
@@ -401,7 +413,6 @@ Table.propTypes = {
   style: PropTypes.string,
   stateCb: PropTypes.func,
   stateVals: PropTypes.func,
-  showPending: PropTypes.bool,
   ignoredFields: PropTypes.arrayOf(PropTypes.string),
   enableColumnFilter: PropTypes.bool
 };

--- a/src/components/table/Table.js
+++ b/src/components/table/Table.js
@@ -13,20 +13,23 @@ import "./Table.css";
 //Attempts to format the header from the column names, but can be passed a header array instead.
 
 const Table = props => {
-  const initData = [];
+  const alternateData = [];
+  const initData = props.data || alternateData;
 
-  const [data, setData] = useState(props.data || initData);
+  const [data, setData] = useState(initData);
   const [header, setHeader] = useState(props.header || []);
   const [columns, setColumns] = useState([]);
   const [rowcount, setRowcount] = useState("");
   const stateVals = props.hasOwnProperty("stateVals") ? altObj(props.stateVals()) : {};
   const [displayColumnFilter, setDisplayColumnFilter] = useState(false);
-  const showPending = props.showPending;
+  const [showPending, setShowPending] = useState(props.showPending || false);
 
   useEffect(() => {
     validateProps();
-    if (!Array.isArray(props.data)) getData();
-    else parseData(props.data);
+    if (hasData(props.service)) {
+      setShowPending(true);
+      getData();
+    } else parseData(initData);
   }, []);
 
   function ColumnFilter({ column: { filterValue, setFilter } }) {
@@ -138,7 +141,7 @@ const Table = props => {
     return (
       <>
         <div className="table-main">
-          {showPending && data === initData && <Loading></Loading>}
+          {showPending && data === alternateData && <Loading></Loading>}
           <RBTable {...getTableProps()} striped bordered hover>
             <thead>
               {headerGroups.map((headerGroup, index) => {
@@ -295,7 +298,8 @@ const Table = props => {
   };
 
   const parseData = data => {
-    if (showPending && data === initData) return;
+    console.log("show pending ???", showPending && data === alternateData);
+    if (showPending && data === alternateData) return;
 
     const noDataFound = "No Data Found";
     let noDataObj = [{}];

--- a/src/pages/admin/auditLog/AuditLog.js
+++ b/src/pages/admin/auditLog/AuditLog.js
@@ -1,19 +1,18 @@
-import React, {useState} from "react";
+import React, { useState } from "react";
 import Table from "../../../components/table/Table";
-import {auditlog, errorlog} from "../../../services/serviceWrapper";
+import { auditlog, errorlog } from "../../../services/serviceWrapper";
 import Title from "../../../components/title/Title";
-import {Col, Container} from "react-bootstrap";
+import { Col, Container } from "react-bootstrap";
 import SideNav from "../../../components/sidenav/SideNav";
 import FilterForm from "../../../components/filterForm2/FilterForm";
 import LabelledInput from "../../../components/labelledInput/LabelledInput";
-import LabelledDateTimePickerStartEnd
-    from "../../../components/inputs/LabelledDateTimePickerStartEnd/LabelledDateTimePickerStartEnd";
+import LabelledDateTimePickerStartEnd from "../../../components/inputs/LabelledDateTimePickerStartEnd/LabelledDateTimePickerStartEnd";
 import Main from "../../../components/main/Main";
 
 const AuditLog = ({ name }) => {
   const cb = function(result) {};
-  const [data,setData] = useState([]);
-  const [refreshKey,setRefreshKey] = useState(1);
+  const [data, setData] = useState();
+  const [refreshKey, setRefreshKey] = useState(1);
   let sDate = new Date();
   let eDate = new Date();
   eDate.setDate(eDate.getDate() + 1);
@@ -21,103 +20,108 @@ const AuditLog = ({ name }) => {
   const [startDate, setStartDate] = useState(sDate);
   const [endDate, setEndDate] = useState(eDate);
   const auditActions = [
-        {value:'ALL_ACTIONS', label:'ALL_ACTIONS'},
-        {value:'CREATE_UDR', label:'CREATE_UDR'},
-        {value:'UPDATE_UDR', label:'UPDATE_UDR'},
-        {value:'UPDATE_UDR_META', label:'UPDATE_UDR_META'},
-        {value:'DELETE_UDR', label:'DELETE_UDR'},
-        {value:'CREATE_WL', label:'CREATE_WL'},
-        {value:'UPDATE_WL', label:'UPDATE_WL'},
-        {value:'DELETE_WL', label:'DELETE_WL'},
-        {value:'LOAD_APIS', label:'LOAD_APIS'},
-        {value:'LOAD_PNR', label:'LOAD_PNR'},
-        {value:'CREATE_USER', label:'CREATE_USER'},
-        {value:'UPDATE_USER', label:'UPDATE_USER'},
-        {value:'SUSPEND_USER', label:'SUSPEND_USER'},
-        {value:'DELETE_USER', label:'DELETE_USER'},
-        {value:'TARGETING_RUN', label:'TARGETING_RUN'},
-        {value:'LOADER_RUN', label:'LOADER_RUN'},
-        {value:'UPDATE_DASHBOARD_RUN', label:'UPDATE_DASHBOARD_RUN'},
-        {value:'MESSAGE_INGEST_PARSING', label:'MESSAGE_INGEST_PARSING'},
-        {value:'RULE_HIT_CASE_OPEN', label:'RULE_HIT_CASE_OPEN'},
-        {value:'DISPOSITION_STATUS_CHANGE', label:'DISPOSITION_STATUS_CHANGE'}
-    ];
+    { value: "ALL_ACTIONS", label: "ALL_ACTIONS" },
+    { value: "CREATE_UDR", label: "CREATE_UDR" },
+    { value: "UPDATE_UDR", label: "UPDATE_UDR" },
+    { value: "UPDATE_UDR_META", label: "UPDATE_UDR_META" },
+    { value: "DELETE_UDR", label: "DELETE_UDR" },
+    { value: "CREATE_WL", label: "CREATE_WL" },
+    { value: "UPDATE_WL", label: "UPDATE_WL" },
+    { value: "DELETE_WL", label: "DELETE_WL" },
+    { value: "LOAD_APIS", label: "LOAD_APIS" },
+    { value: "LOAD_PNR", label: "LOAD_PNR" },
+    { value: "CREATE_USER", label: "CREATE_USER" },
+    { value: "UPDATE_USER", label: "UPDATE_USER" },
+    { value: "SUSPEND_USER", label: "SUSPEND_USER" },
+    { value: "DELETE_USER", label: "DELETE_USER" },
+    { value: "TARGETING_RUN", label: "TARGETING_RUN" },
+    { value: "LOADER_RUN", label: "LOADER_RUN" },
+    { value: "UPDATE_DASHBOARD_RUN", label: "UPDATE_DASHBOARD_RUN" },
+    { value: "MESSAGE_INGEST_PARSING", label: "MESSAGE_INGEST_PARSING" },
+    { value: "RULE_HIT_CASE_OPEN", label: "RULE_HIT_CASE_OPEN" },
+    { value: "DISPOSITION_STATUS_CHANGE", label: "DISPOSITION_STATUS_CHANGE" }
+  ];
   const visibleCols = ["actionType", "status", "message", "user", "timestamp"];
   const preFetchCallback = params => {
-      let parsedParams = "";
-      if(params) {
-          if (params.dateRange) {
-              parsedParams += "?startDate=" + params.dateRange.etaStart.toISOString() + "&endDate=" + params.dateRange.etaEnd.toISOString();
-          };
-          if (params.action) {
-              parsedParams += "&action=" + params.action;
-          };
-          if (params.user) {
-              parsedParams += "&user=" + params.user;
-          };
-      };
-      return parsedParams;
+    let parsedParams = "";
+    if (params) {
+      if (params.dateRange) {
+        parsedParams +=
+          "?startDate=" +
+          params.dateRange.etaStart.toISOString() +
+          "&endDate=" +
+          params.dateRange.etaEnd.toISOString();
+      }
+      if (params.action) {
+        parsedParams += "&action=" + params.action;
+      }
+      if (params.user) {
+        parsedParams += "&user=" + params.user;
+      }
+    }
+    return parsedParams;
   };
 
   const setDataWrapper = res => {
-      setData(res);
-      setRefreshKey(refreshKey+1);
+    setData(res);
+    setRefreshKey(refreshKey + 1);
   };
 
-
   return (
-      <>
-          <SideNav>
-              <Col>
-                  <FilterForm
-                      service={auditlog.get}
-                      paramCallback={preFetchCallback}
-                      callback={setDataWrapper}
-                  >
-                      <br />
-                      <LabelledInput
-                          labelText="User"
-                          datafield="user"
-                          name="user"
-                          inputType="text"
-                          callback={cb}
-                          alt="User"
-                      />
-                      <LabelledInput
-                          labelText="Actions"
-                          datafield="action"
-                          inputType="select"
-                          name="action"
-                          placeholder="Choose Action..."
-                          options={auditActions}
-                          required={true}
-                          alt="nothing"
-                          callback={cb}
-                      />
-                      <LabelledDateTimePickerStartEnd
-                          labelText="Date Range"
-                          inputType="date"
-                          name="datefield"
-                          datafield={["dateRange"]}
-                          inputVal={{etaStart:startDate, etaEnd:endDate}}
-                          callback={cb}
-                          startDate={startDate}
-                          endDate={endDate}
-                          endMut={cb}
-                          startMut={cb}
-                          alt="datefield"
-                      />
-                  </FilterForm>
-              </Col>
-          </SideNav>
-          <Main>
-      <Title title={name}></Title>
-      <Table data={data}
-             key={refreshKey}
-             id="Audit Log"
-             callback={cb}
-             header={visibleCols}></Table>
-          </Main>
+    <>
+      <SideNav>
+        <Col>
+          <FilterForm
+            service={auditlog.get}
+            paramCallback={preFetchCallback}
+            callback={setDataWrapper}
+          >
+            <br />
+            <LabelledInput
+              labelText="User"
+              datafield="user"
+              name="user"
+              inputType="text"
+              callback={cb}
+              alt="User"
+            />
+            <LabelledInput
+              labelText="Actions"
+              datafield="action"
+              inputType="select"
+              name="action"
+              placeholder="Choose Action..."
+              options={auditActions}
+              required={true}
+              alt="nothing"
+              callback={cb}
+            />
+            <LabelledDateTimePickerStartEnd
+              labelText="Date Range"
+              inputType="date"
+              name="datefield"
+              datafield={["dateRange"]}
+              inputVal={{ etaStart: startDate, etaEnd: endDate }}
+              callback={cb}
+              startDate={startDate}
+              endDate={endDate}
+              endMut={cb}
+              startMut={cb}
+              alt="datefield"
+            />
+          </FilterForm>
+        </Col>
+      </SideNav>
+      <Main>
+        <Title title={name}></Title>
+        <Table
+          data={data}
+          key={refreshKey}
+          id="Audit Log"
+          callback={cb}
+          header={visibleCols}
+        ></Table>
+      </Main>
     </>
   );
 };

--- a/src/pages/admin/errorLog/ErrorLog.js
+++ b/src/pages/admin/errorLog/ErrorLog.js
@@ -1,19 +1,18 @@
-import React, {useState} from "react";
+import React, { useState } from "react";
 import Table from "../../../components/table/Table";
-import {errorlog, flights} from "../../../services/serviceWrapper";
+import { errorlog, flights } from "../../../services/serviceWrapper";
 import Title from "../../../components/title/Title";
-import {Col, Container} from "react-bootstrap";
+import { Col, Container } from "react-bootstrap";
 import LabelledInput from "../../../components/labelledInput/LabelledInput";
 import FilterForm from "../../../components/filterForm2/FilterForm";
 import Main from "../../../components/main/Main";
-import LabelledDateTimePickerStartEnd
-    from "../../../components/inputs/LabelledDateTimePickerStartEnd/LabelledDateTimePickerStartEnd";
+import LabelledDateTimePickerStartEnd from "../../../components/inputs/LabelledDateTimePickerStartEnd/LabelledDateTimePickerStartEnd";
 import SideNav from "../../../components/sidenav/SideNav";
 
 const ErrorLog = ({ name }) => {
   const cb = function(result) {};
-  const [data,setData] = useState([]);
-  const [refreshKey,setRefreshKey] = useState(1);
+  const [data, setData] = useState();
+  const [refreshKey, setRefreshKey] = useState(1);
   let sDate = new Date();
   let eDate = new Date();
   eDate.setDate(eDate.getDate() + 1);
@@ -21,72 +20,76 @@ const ErrorLog = ({ name }) => {
   const [startDate, setStartDate] = useState(sDate);
   const [endDate, setEndDate] = useState(eDate);
 
-
   const visibleCols = ["errorId", "errorCode", "errorDescription", "errorTimestamp"];
 
   const preFetchCallback = params => {
-      let parsedParams = "";
-      if(params) {
-          if (params.dateRange) {
-              parsedParams += "?startDate=" + params.dateRange.etaStart.toISOString() + "&endDate=" + params.dateRange.etaEnd.toISOString();
-          };
-          if (params.errorCode) {
-              parsedParams += "&code=" + params.errorCode;
-          };
-      };
-      return parsedParams;
+    let parsedParams = "";
+    if (params) {
+      if (params.dateRange) {
+        parsedParams +=
+          "?startDate=" +
+          params.dateRange.etaStart.toISOString() +
+          "&endDate=" +
+          params.dateRange.etaEnd.toISOString();
+      }
+      if (params.errorCode) {
+        parsedParams += "&code=" + params.errorCode;
+      }
+    }
+    return parsedParams;
   };
 
   const setDataWrapper = res => {
     setData(res);
-    setRefreshKey(refreshKey+1);
+    setRefreshKey(refreshKey + 1);
   };
 
   return (
-      <>
-          <SideNav>
-              <Col>
-                  <FilterForm
-                      service={errorlog.get}
-                      paramCallback={preFetchCallback}
-                      callback={setDataWrapper}
-                  >
-                      <br />
-                      <LabelledInput
-                          labelText="Error Code"
-                          datafield="errorCode"
-                          name="code"
-                          inputType="text"
-                          callback={cb}
-                          alt="Error Code"
-                      />
-                      <LabelledDateTimePickerStartEnd
-                          labelText="Date Range"
-                          inputType="date"
-                          name="datepicker"
-                          datafield={["dateRange"]}
-                          inputVal={{etaStart:startDate, etaEnd:endDate}}
-                          callback={cb}
-                          startDate={startDate}
-                          endDate={endDate}
-                          endMut={cb}
-                          startMut={cb}
-                          alt="datepicker"
-                      />
-                  </FilterForm>
-              </Col>
-          </SideNav>
-          <Main>
-      <Title title={name}></Title>
+    <>
+      <SideNav>
+        <Col>
+          <FilterForm
+            service={errorlog.get}
+            paramCallback={preFetchCallback}
+            callback={setDataWrapper}
+          >
+            <br />
+            <LabelledInput
+              labelText="Error Code"
+              datafield="errorCode"
+              name="code"
+              inputType="text"
+              callback={cb}
+              alt="Error Code"
+            />
+            <LabelledDateTimePickerStartEnd
+              labelText="Date Range"
+              inputType="date"
+              name="datepicker"
+              datafield={["dateRange"]}
+              inputVal={{ etaStart: startDate, etaEnd: endDate }}
+              callback={cb}
+              startDate={startDate}
+              endDate={endDate}
+              endMut={cb}
+              startMut={cb}
+              alt="datepicker"
+            />
+          </FilterForm>
+        </Col>
+      </SideNav>
+      <Main>
+        <Title title={name}></Title>
 
-      <Table
-        data={data}
-        id="errorLog"
-        callback={cb}
-        header={visibleCols}
-        key={refreshKey}
-      ></Table>
-          </Main>
+        <Table
+          data={data}
+          id="errorLog"
+          callback={cb}
+          header={visibleCols}
+          key={refreshKey}
+          showPending={true}
+        ></Table>
+      </Main>
     </>
   );
 };

--- a/src/pages/admin/errorLog/ErrorLog.js
+++ b/src/pages/admin/errorLog/ErrorLog.js
@@ -87,7 +87,6 @@ const ErrorLog = ({ name }) => {
           callback={cb}
           header={visibleCols}
           key={refreshKey}
-          showPending={true}
         ></Table>
       </Main>
     </>

--- a/src/pages/admin/manageUsers/ManageUsers.js
+++ b/src/pages/admin/manageUsers/ManageUsers.js
@@ -190,7 +190,6 @@ const ManageUsers = props => {
           key={refreshKey}
           header={headers}
           enableColumnFilter={true}
-          showPending={true}
         ></Table>
         <UserModal
           show={showModal}

--- a/src/pages/admin/signUpRequests/SignUpRequests.js
+++ b/src/pages/admin/signUpRequests/SignUpRequests.js
@@ -164,7 +164,6 @@ const SignUpRequests = () => {
           id="SigUpRequest"
           callback={cb}
           key={refreshKey}
-          showPending={true}
         ></Table>
       </Main>
     </>

--- a/src/pages/flightPax/FlightPax.js
+++ b/src/pages/flightPax/FlightPax.js
@@ -19,9 +19,9 @@ import Main from "../../components/main/Main";
 const FlightPax = props => {
   const cb = function(result) {};
 
-  const [data, setData] = useState([]);
-  const [hitData, setHitData] = useState([{}]);
-  const [allData, setAllData] = useState([{}]);
+  const [data, setData] = useState();
+  const [hitData, setHitData] = useState();
+  const [allData, setAllData] = useState();
   const [tab, setTab] = useState("all");
   const [key, setKey] = useState(0);
   const flightData = hasData(props.location.state?.data) ? props.location.state.data : {};

--- a/src/pages/flights/Flights.js
+++ b/src/pages/flights/Flights.js
@@ -22,9 +22,9 @@ const Flights = props => {
     sortBy: [{ id: "timer", desc: false }]
   };
 
-  const [data, setData] = useState([{}]);
-  const [hitData, setHitData] = useState([{}]);
-  const [allData, setAllData] = useState([{}]);
+  const [data, setData] = useState();
+  const [hitData, setHitData] = useState();
+  const [allData, setAllData] = useState();
   const [tab, setTab] = useState("all");
   const [tablekey, setTablekey] = useState(0);
   const [tableState, setTableState] = useState(initTableState);

--- a/src/pages/tools/queryrules/QRDetails.js
+++ b/src/pages/tools/queryrules/QRDetails.js
@@ -72,7 +72,6 @@ const QRDetails = props => {
         header={headers}
         id="Query Details"
         callback={cb}
-        showPending={true}
         key={key}
       ></Table>
     </Container>

--- a/src/pages/tools/queryrules/Rules.js
+++ b/src/pages/tools/queryrules/Rules.js
@@ -222,7 +222,6 @@ const Rules = props => {
         id="Rules"
         callback={cb}
         header={header}
-        showPending={true}
         key={`table-${tablekey}`}
       ></Table>
       {showModal && (

--- a/src/pages/tools/watchlist/Watchlist.js
+++ b/src/pages/tools/watchlist/Watchlist.js
@@ -22,7 +22,7 @@ const Watchlist = props => {
   const [showMiniModal, setShowMiniModal] = useState(false);
   const [id, setId] = useState(0);
   const [key, setKey] = useState(0);
-  const [data, setData] = useState([]);
+  const [data, setData] = useState();
   const [wlcatData, setWlcatData] = useState([]);
   const [editRow, setEditRow] = useState({});
   const [tab, setTab] = useState(isDox ? TAB.DOX : TAB.PAX); // default to pax when no param is in the uri

--- a/src/pages/vetting/Vetting.js
+++ b/src/pages/vetting/Vetting.js
@@ -431,7 +431,6 @@ const Vetting = props => {
           callback={onTableChange}
           header={Headers}
           key={data}
-          showPending={true}
         />
 
         <ReviewPVL

--- a/src/pages/vetting/Vetting.js
+++ b/src/pages/vetting/Vetting.js
@@ -158,7 +158,7 @@ const Vetting = props => {
   sDate.setHours(sDate.getHours() - 7);
   const [startDate, setStartDate] = useState(sDate);
   const [endDate, setEndDate] = useState(eDate);
-  const [data, setData] = useState([]);
+  const [data, setData] = useState();
   const [hitCategoryOptions, setHitCategoryOptions] = useState();
   const [refreshKey, setRefreshKey] = useState(0);
   const showDateTimePicker = useRef(false);
@@ -431,6 +431,7 @@ const Vetting = props => {
           callback={onTableChange}
           header={Headers}
           key={data}
+          showPending={true}
         />
 
         <ReviewPVL


### PR DESCRIPTION
Revisited the spinner logic. Original PR did not cover all cases.

Changed the logic so the caller does not need to indicate an initial pending state (eg, if the caller is doing the fetch and updating Table with the results later). Now Table assumes it is in a pending (spinning) state if:
- there is no service call and the data passed is undefined
- a service call is passed but hasn't resolved yet

If the data passed is an empty array or the service call resolves to an empty array, Table assumes the dataset is resolved hides the spinner.

Updated existing callers of Table to remove the initial empty array being passed so the spinner will show until the data is loaded.