### PR TITLE
fix missing scroller on admin and tools landing pages

### DIFF
--- a/src/components/main/Main.css
+++ b/src/components/main/Main.css
@@ -40,6 +40,18 @@
   height: calc(100vh - 60px);
 }
 
+.full-cards {
+  min-width: 255px;
+  margin-left: 20px;
+  margin-right: 20px;
+  position: absolute;
+  top: auto;
+  overflow: auto;
+  padding: 10px;
+  width: calc(100vw - 40px);
+  height: calc(100vh - 106px);
+}
+
 @media (max-width: 768px) {
   .main {
     left: 34px !important;

--- a/src/pages/admin/Admin.js
+++ b/src/pages/admin/Admin.js
@@ -1,5 +1,6 @@
 import React from "react";
 import Title from "../../components/title/Title";
+import Main from "../../components/main/Main";
 import { Card, CardDeck, Container } from "react-bootstrap";
 import { hasData, getEndpoint } from "../../utils/utils";
 import { Link } from "@reach/router";
@@ -14,7 +15,7 @@ const Admin = props => {
       <>
         <Title title="Admin" />
 
-        <div className="container">
+        <Main className="full-cards">
           <CardDeck className="page-deck">
             {children.map(info => {
               const data = info.props;
@@ -49,7 +50,7 @@ const Admin = props => {
               );
             })}
           </CardDeck>
-        </div>
+        </Main>
       </>
     );
 

--- a/src/pages/tools/Tools.js
+++ b/src/pages/tools/Tools.js
@@ -1,10 +1,10 @@
 import React from "react";
 import Title from "../../components/title/Title";
+import Main from "../../components/main/Main";
 import { Card, CardDeck } from "react-bootstrap";
 import { asArray, getEndpoint } from "../../utils/utils";
 import { Link } from "@reach/router";
 import "./Tools.css";
-import ExternalLink from "../../components/externalLink/ExternalLink";
 
 const Tools = props => {
   const children = props.children?.props?.children;
@@ -15,7 +15,7 @@ const Tools = props => {
       <>
         <Title title="Tools" />
 
-        <div className="container">
+        <Main className="full-cards">
           <CardDeck className="page-deck">
             {tiles.map(info => {
               const data = info.props;
@@ -37,7 +37,7 @@ const Tools = props => {
               );
             })}
           </CardDeck>
-        </div>
+        </Main>
       </>
     );
 


### PR DESCRIPTION
fixes #230 . Added the default page layout component (Main) with an extra style to exclude the title component when scrolling for pages where the content height is not fixed like it is for grid pages. Fixed both Admin and Tools landing pages. 

Test by resizing the /admin and /tools pages width and height so the cards drop to two or one column and extend beyond the height of the page. Vertical scroller should appear so you can view all tiles plus a margin at the very bottom.