### PR TITLE
fix tab xl8 text not triggering tab click handler

### DIFF
--- a/src/pages/flightPax/FlightPax.js
+++ b/src/pages/flightPax/FlightPax.js
@@ -99,8 +99,22 @@ const FlightPax = props => {
 
   const tabs = (
     <Tabs defaultActiveKey="all" id="flightPaxTabs">
-      <Tab eventKey="all" title={<Xl8 xid="fp001">All</Xl8>}></Tab>
-      <Tab eventKey="hits" title={<Xl8 xid="fp002">Hits</Xl8>}></Tab>
+      <Tab
+        eventKey="all"
+        title={
+          <Xl8 xid="fp001" id="flightPaxTabs-tab-all">
+            All
+          </Xl8>
+        }
+      ></Tab>
+      <Tab
+        eventKey="hits"
+        title={
+          <Xl8 xid="fp002" id="flightPaxTabs-tab-hits">
+            Hits
+          </Xl8>
+        }
+      ></Tab>
     </Tabs>
   );
 


### PR DESCRIPTION
fixes #281 Clicking on the text inside the tab header was not causing the data to reload because the xl8 tab was blocking it. Should work anywhere you click in the tab header now.