### PR TITLE
uppercase code and set max length = 2

### DIFF
--- a/src/components/labelledInput/LabelledInput.js
+++ b/src/components/labelledInput/LabelledInput.js
@@ -30,7 +30,7 @@ class LabelledInput extends Component {
 
     this.onChange = this.onChange.bind(this);
     this.onChangeArray = this.onChangeArray.bind(this);
-    this.onMultiSelecChange = this.onMultiSelecChange.bind(this);
+    this.onMultiSelectChange = this.onMultiSelectChange.bind(this);
     this.onChangeDatePicker = this.onChangeDatePicker.bind(this);
 
     this.state = {
@@ -71,7 +71,7 @@ class LabelledInput extends Component {
     this.props.callback(e);
   }
 
-  onMultiSelecChange(e) {
+  onMultiSelectChange(e) {
     this.setState({
       inputVal: e,
       isValid: hasData(e) || this.props.required !== REQUIRED
@@ -131,10 +131,11 @@ class LabelledInput extends Component {
           name={this.props.name}
           inputType={this.props.inputType}
           inputVal={alt(this.state.inputVal)}
-          callback={this.onChange}
           required={this.state.required}
           placeholder={this.state.placeholder}
+          maxlength={this.props.maxlength}
           readOnly={this.props.readOnly}
+          callback={this.onChange}
         />
       );
     }
@@ -147,7 +148,7 @@ class LabelledInput extends Component {
           name={this.props.name}
           inputType={this.props.inputType}
           selected={this.props.inputVal}
-          callback={type === "select" ? this.onChange : this.onMultiSelecChange}
+          callback={type === "select" ? this.onChange : this.onMultiSelectChange}
           required={this.state.required}
           placeholder={this.state.placeholder}
           options={this.state.options}

--- a/src/pages/admin/codeEditor/creditcardtype/CreditCardTypeModal.js
+++ b/src/pages/admin/codeEditor/creditcardtype/CreditCardTypeModal.js
@@ -12,7 +12,6 @@ const CreditCardTypeModal = props => {
   const cb = function(result) {};
   const data = props.editRowDetails || {};
 
-  // console.log(data);
   const postSubmit = (status = ACTION.CANCEL, results) => {
     props.onHide();
 
@@ -34,8 +33,11 @@ const CreditCardTypeModal = props => {
     });
   };
 
-  const customButtons = props.isEdit
-    ? [
+  let customButtons = [];
+
+  if (props.isEdit) {
+    if (data.originId) {
+      customButtons.push(
         <Button
           type="button"
           className="m-2 outline-dark-outline"
@@ -44,22 +46,25 @@ const CreditCardTypeModal = props => {
           onClick={restoreSpecificCode}
         >
           <Xl8 xid="cctm001">Restore</Xl8>
-        </Button>,
-        <Button
-          type="button"
-          className="m-2 outline-dark-outline"
-          variant="outline-dark"
-          key="delete"
-          onClick={() => {
-            codeEditor.delete.deleteCctype(data.id).then(res => {
-              postSubmit(ACTION.DELETE);
-            });
-          }}
-        >
-          <Xl8 xid="cctm002">Delete</Xl8>
         </Button>
-      ]
-    : [];
+      );
+    }
+    customButtons.push(
+      <Button
+        type="button"
+        className="m-2 outline-dark-outline"
+        variant="outline-dark"
+        key="delete"
+        onClick={() => {
+          codeEditor.delete.deleteCctype(data.id).then(res => {
+            postSubmit(ACTION.DELETE);
+          });
+        }}
+      >
+        <Xl8 xid="cctm002">Delete</Xl8>
+      </Button>
+    );
+  }
 
   return (
     <Modal
@@ -99,8 +104,9 @@ const CreditCardTypeModal = props => {
               max-length="2"
               name="code"
               required={true}
+              maxlength="2"
               alt="nothing"
-              inputVal={data.code}
+              inputVal={data.code?.toUpperCase()}
               callback={cb}
               spacebetween
             />

--- a/src/pages/admin/codeEditor/creditcardtype/CreditCardTypeModal.js
+++ b/src/pages/admin/codeEditor/creditcardtype/CreditCardTypeModal.js
@@ -23,7 +23,6 @@ const CreditCardTypeModal = props => {
     res.id = data.id || 0;
     res.originId = data.originId || 0;
 
-    console.log(res);
     return [res];
   };
 

--- a/src/services/serviceWrapper.js
+++ b/src/services/serviceWrapper.js
@@ -320,10 +320,7 @@ export const codeEditor = {
     createCarrier: body => post(CODES_CARRIER, BASEHEADER, stringify(body)),
     createCountry: body => post(CODES_COUNTRY, BASEHEADER, stringify(body)),
     createAirport: body => post(CODES_AIRPORT, BASEHEADER, stringify(body)),
-    createCctype: body => {
-      console.log(body);
-      return post(CODES_CCTYPE, BASEHEADER, stringify(body));
-    }
+    createCctype: body => post(CODES_CCTYPE, BASEHEADER, stringify(body))
   },
   delete: {
     deleteCarrier: id => del(CODES_CARRIER, BASEHEADER, id),


### PR DESCRIPTION
minor - upper case the credit card type codes in Code Editor, and set the maxlength = 2. Also removed the "Restore" option for new codes that can't be restored from the CreditCardTypeRestore table (no originId).

Will do the same for the remaining types under code editor later.