### PR TITLE
Fix/roles

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -272,7 +272,7 @@ export default class App extends React.Component {
                           </RoleAuthenticator>
                           <RoleAuthenticator
                             path="vetting"
-                            roles={[ROLE.ADMIN, ROLE.CASEMGR]}
+                            roles={[ROLE.ADMIN, ROLE.PAXVWR]}
                           >
                             <PriorityVetting path="/"></PriorityVetting>
                           </RoleAuthenticator>

--- a/src/App.js
+++ b/src/App.js
@@ -7,9 +7,6 @@ import "bootstrap/dist/css/bootstrap.min.css";
 import "font-awesome/css/font-awesome.min.css";
 import "./App.css";
 
-// import ErrorBoundary from "./components/errorBoundary/ErrorBoundary";
-// import Loading from "./components/loading/Loading";
-
 import Xl8 from "./components/xl8/Xl8";
 
 import Authenticator from "./context/authenticator/Authenticator";
@@ -233,7 +230,6 @@ export default class App extends React.Component {
                       {UNAUTHED}
                       <RoleAuthenticator
                         path="/"
-                        alt={UNAUTHED}
                         roles={[
                           ROLE.ADMIN,
                           ROLE.PAXVWR,
@@ -249,65 +245,56 @@ export default class App extends React.Component {
                         <Home path="/gtas">
                           <Page404 default></Page404>
                           <Redirect from="/gtas" to="/gtas/flights" noThrow />
-                          <Flights path="flights"></Flights>
-                          <FlightPax path="flightpax/:id"></FlightPax>
-                          <PriorityVetting path="vetting"></PriorityVetting>
+                          <RoleAuthenticator
+                            path="flights"
+                            roles={[ROLE.ADMIN, ROLE.FLIGHTVWR]}
+                          >
+                            <Flights path="/"></Flights>
+                          </RoleAuthenticator>
+                          <RoleAuthenticator
+                            path="flightpax"
+                            roles={[ROLE.ADMIN, ROLE.PAXVWR]}
+                          >
+                            <FlightPax path="/:id"></FlightPax>
+                          </RoleAuthenticator>
+                          <RoleAuthenticator
+                            path="paxDetail/:flightId/:paxId"
+                            roles={[ROLE.ADMIN, ROLE.PAXVWR]}
+                          >
+                            <PaxDetail path="/">
+                              <Summary path="summary" default></Summary>
+                              <APIS path="apis"></APIS>
+                              <PNR path="pnr"></PNR>
+                              <FlightHistory path="flighthistory"></FlightHistory>
+                              <LinkAnalysis path="linkanalysis"></LinkAnalysis>
+                              <UploadAttachment path="uploadattachment"></UploadAttachment>
+                            </PaxDetail>
+                          </RoleAuthenticator>
+                          <RoleAuthenticator
+                            path="vetting"
+                            roles={[ROLE.ADMIN, ROLE.CASEMGR]}
+                          >
+                            <PriorityVetting path="/"></PriorityVetting>
+                          </RoleAuthenticator>
                           <Tools path="tools">
-                            <Rules
-                              name={<Xl8 xid="app001">Rules</Xl8>}
-                              desc={
-                                <Xl8 xid="app002">
-                                  View or edit rules for generating hits
-                                </Xl8>
-                              }
-                              path="rules"
-                              icon="fa-address-book-o"
-                            ></Rules>
-                            <Rules name="Rules" path="rules/:mode" hideTile></Rules>
-                            <Queries
-                              name={<Xl8 xid="app003">Queries</Xl8>}
-                              desc={
-                                <Xl8 xid="app004">
-                                  View or edit queries of system data
-                                </Xl8>
-                              }
-                              path="queries"
-                              icon="fa-search"
-                            ></Queries>
-                            <QRDetails path="qrdetails" hideTile></QRDetails>
-                            <Watchlist
-                              name={<Xl8 xid="app005">Watchlist</Xl8>}
-                              desc={
-                                <Xl8 xid="app006">
-                                  View or add passenger and document watchlists
-                                </Xl8>
-                              }
-                              path="watchlist"
-                              icon="fa-user-secret"
-                            ></Watchlist>
-                            <Watchlist
-                              path="watchlist/:mode"
-                              name="Watchlist"
-                              hideTile
-                            ></Watchlist>
-                            <About
-                              name={<Xl8 xid="app007">About</Xl8>}
-                              desc={
-                                <Xl8 xid="app008">View system information details</Xl8>
-                              }
-                              path="about"
-                              icon="fa-info-circle"
-                            ></About>
+                            <Rules path="rules"></Rules>
+                            <Rules path="rules/:mode"></Rules>
+                            <Queries path="queries"></Queries>
+                            <QRDetails path="qrdetails"></QRDetails>
+                            <Watchlist path="watchlist"></Watchlist>
+                            <Watchlist path="watchlist/:mode"></Watchlist>
+                            <About path="about"></About>
                           </Tools>
                           <ChangePassword path="user/change-password"></ChangePassword>
                           <Search path="search/:searchParam"></Search>
                           <ChangePassword path="user/change-password/:userId"></ChangePassword>
-                          <SeatChart path="seat-chart/:flightId/:paxId/:currentPaxSeat"></SeatChart>
                           <RoleAuthenticator
-                            path="langEditor"
-                            alt={UNAUTHED}
-                            roles={[ROLE.ADMIN]}
+                            path="seat-chart/:flightId/:paxId/:currentPaxSeat"
+                            roles={[ROLE.ADMIN, ROLE.PAXVWR]}
                           >
+                            <SeatChart path="/"></SeatChart>
+                          </RoleAuthenticator>
+                          <RoleAuthenticator path="langEditor" roles={[ROLE.ADMIN]}>
                             <LanguageEditor path="/"></LanguageEditor>
                           </RoleAuthenticator>
                           <RoleAuthenticator
@@ -428,14 +415,6 @@ export default class App extends React.Component {
                               ></Auxiliary>
                             </Admin>
                           </RoleAuthenticator>
-                          <PaxDetail path="paxDetail/:flightId/:paxId">
-                            <Summary path="summary" default></Summary>
-                            <APIS path="apis"></APIS>
-                            <PNR path="pnr"></PNR>
-                            <FlightHistory path="flighthistory"></FlightHistory>
-                            <LinkAnalysis path="linkanalysis"></LinkAnalysis>
-                            <UploadAttachment path="uploadattachment"></UploadAttachment>
-                          </PaxDetail>
                           {UNAUTHED}
                         </Home>
                       </RoleAuthenticator>

--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -94,7 +94,7 @@ const Header = () => {
           >
             <Xl8 xid="head001">Flights</Xl8>
           </Nav.Link>
-          <RoleAuthenticator roles={[ROLE.ADMIN, ROLE.CASEMGR]} alt={<></>}>
+          <RoleAuthenticator roles={[ROLE.ADMIN, ROLE.PAXVWR]} alt={<></>}>
             <Nav.Link
               as={Link}
               to="vetting"

--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -77,9 +77,11 @@ const Header = () => {
   return (
     <Navbar sticky="top" expand="md" className="header-navbar" variant="dark">
       <Navbar.Brand className="header-navbar-brand">
-        <Link to="flights" onClick={() => clickTab(htab.FLIGHT)}>
-          <img src={wcoLogo} />
-        </Link>
+        <RoleAuthenticator roles={[ROLE.ADMIN, ROLE.FLIGHTVWR]} alt={<></>}>
+          <Link to="flights" onClick={() => clickTab(htab.FLIGHT)}>
+            <img src={wcoLogo} />
+          </Link>
+        </RoleAuthenticator>
       </Navbar.Brand>
       <Navbar.Toggle aria-controls="responsive-navbar-nav" ref={toggleRef} />
       <Navbar.Collapse>
@@ -92,14 +94,16 @@ const Header = () => {
           >
             <Xl8 xid="head001">Flights</Xl8>
           </Nav.Link>
-          <Nav.Link
-            as={Link}
-            to="vetting"
-            className={`${getActiveClass(htab.VETTING)}`}
-            onClick={() => clickTab(htab.VETTING)}
-          >
-            <Xl8 xid="head002">Vetting</Xl8>
-          </Nav.Link>
+          <RoleAuthenticator roles={[ROLE.ADMIN, ROLE.CASEMGR]} alt={<></>}>
+            <Nav.Link
+              as={Link}
+              to="vetting"
+              className={`${getActiveClass(htab.VETTING)}`}
+              onClick={() => clickTab(htab.VETTING)}
+            >
+              <Xl8 xid="head002">Vetting</Xl8>
+            </Nav.Link>
+          </RoleAuthenticator>
           <Nav.Link
             as={Link}
             to="tools"
@@ -108,7 +112,7 @@ const Header = () => {
           >
             <Xl8 xid="head004">Tools</Xl8>
           </Nav.Link>
-          <RoleAuthenticator alt={<></>} roles={[ROLE.ADMIN]}>
+          <RoleAuthenticator roles={[ROLE.ADMIN]} alt={<></>}>
             <Nav.Link
               as={Link}
               to="admin"

--- a/src/components/raqb/RAQB.js
+++ b/src/components/raqb/RAQB.js
@@ -7,7 +7,6 @@ import {
 } from "react-awesome-query-builder";
 import "react-awesome-query-builder/lib/css/styles.css";
 import Xl8 from "../../components/xl8/Xl8";
-// import Loading from "../../components/loading/Loading";
 import { operators } from "./config";
 import { importToTreeObject, exportToQueryObject } from "./utils";
 

--- a/src/context/roleAuthenticator/RoleAuthenticator.js
+++ b/src/context/roleAuthenticator/RoleAuthenticator.js
@@ -1,9 +1,12 @@
 import React, { useContext } from "react";
 import { UserContext } from "../user/UserContext";
 import { asArray, titleCase } from "../../utils/utils";
+import PageUnauthorized from "../../pages/pageUnauthorized/PageUnauthorized";
+
+const UNAUTHED = <PageUnauthorized path="pageUnauthorized"></PageUnauthorized>;
 
 const RoleAuthenticator = props => {
-  const alt = props.alt ?? <></>;
+  const alt = props.alt ?? UNAUTHED;
   const { getUserState } = useContext(UserContext);
 
   let hasRole = false;

--- a/src/pages/flightPax/FlightPax.js
+++ b/src/pages/flightPax/FlightPax.js
@@ -1,12 +1,14 @@
 import React, { useEffect, useState } from "react";
 import Table from "../../components/table/Table";
-import { flightPassengers } from "../../services/serviceWrapper";
 import Title from "../../components/title/Title";
 import Xl8 from "../../components/xl8/Xl8";
 import LabelledInput from "../../components/labelledInput/LabelledInput";
 import SidenavContainer from "../../components/sidenavContainer/SidenavContainer";
 import { Col, Tabs, Tab } from "react-bootstrap";
+import Main from "../../components/main/Main";
+import RoleAuthenticator from "../../context/roleAuthenticator/RoleAuthenticator";
 import { Link } from "@reach/router";
+import { flightPassengers } from "../../services/serviceWrapper";
 import {
   asArray,
   hasData,
@@ -15,7 +17,7 @@ import {
   localeDateOnly,
   localeDate
 } from "../../utils/utils";
-import Main from "../../components/main/Main";
+import { ROLE } from "../../utils/constants";
 
 const FlightPax = props => {
   const cb = function(result) {};
@@ -50,9 +52,14 @@ const FlightPax = props => {
       Header: ["fp014", "Last Name"],
       Cell: ({ row }) => {
         return (
-          <Link to={`/gtas/paxDetail/${props.id}/${row.original.id}`}>
-            {row.original.lastName}
-          </Link>
+          <RoleAuthenticator
+            alt={row.original.lastName}
+            roles={[ROLE.ADMIN, ROLE.PAXVWR]}
+          >
+            <Link to={`/gtas/paxDetail/${props.id}/${row.original.id}`}>
+              {row.original.lastName}
+            </Link>
+          </RoleAuthenticator>
         );
       }
     },

--- a/src/pages/paxDetail/addToWatchList/AddToWatchlist.js
+++ b/src/pages/paxDetail/addToWatchList/AddToWatchlist.js
@@ -1,10 +1,13 @@
 import React, { useEffect, useState } from "react";
-import { asArray, hasData } from "../../../utils/utils";
 import { Button, Modal, Container, Alert } from "react-bootstrap";
-import { addWLItems, hitcats } from "../../../services/serviceWrapper";
 import Form from "../../../components/form/Form";
 import Xl8 from "../../../components/xl8/Xl8";
 import LabelledInput from "../../../components/labelledInput/LabelledInput";
+import RoleAuthenticator from "../../../context/roleAuthenticator/RoleAuthenticator";
+import { ROLE } from "../../../utils/constants";
+import { addWLItems, hitcats } from "../../../services/serviceWrapper";
+
+import { asArray } from "../../../utils/utils";
 
 const AddToWatchlist = props => {
   const cb = () => {};
@@ -74,7 +77,7 @@ const AddToWatchlist = props => {
   }, []);
 
   return (
-    <>
+    <RoleAuthenticator roles={[ROLE.ADMIN, ROLE.WLMGR]} alt={<></>}>
       <Button variant="outline-danger" size="sm" onClick={handleShow}>
         <Xl8 xid="atw001">Add to Watchlist</Xl8>
       </Button>
@@ -124,7 +127,7 @@ const AddToWatchlist = props => {
           </Container>
         </Modal.Body>
       </Modal>
-    </>
+    </RoleAuthenticator>
   );
 };
 

--- a/src/pages/paxDetail/changeHitStatus/ChangeHitStatus.js
+++ b/src/pages/paxDetail/changeHitStatus/ChangeHitStatus.js
@@ -1,7 +1,9 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
 import { SplitButton, Dropdown, Modal, Button } from "react-bootstrap";
+import RoleAuthenticator from "../../../context/roleAuthenticator/RoleAuthenticator";
 import Xl8 from "../../../components/xl8/Xl8";
+import { ROLE } from "../../../utils/constants";
 
 const ChangeHitStatus = props => {
   const [show, setShow] = useState(false);
@@ -16,7 +18,7 @@ const ChangeHitStatus = props => {
     setShow(false);
   };
   return (
-    <>
+    <RoleAuthenticator roles={[ROLE.ADMIN, ROLE.CASEMGR]} alt={<></>}>
       <SplitButton
         key="paxHitStatus"
         title={<Xl8 xid="chs001">Change Status</Xl8>}
@@ -66,7 +68,7 @@ const ChangeHitStatus = props => {
           </Button>
         </Modal.Footer>
       </Modal>
-    </>
+    </RoleAuthenticator>
   );
 };
 

--- a/src/pages/paxDetail/createManualHit/CreateManualHit.js
+++ b/src/pages/paxDetail/createManualHit/CreateManualHit.js
@@ -1,11 +1,13 @@
 import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { Modal, Button } from "react-bootstrap";
-import { manualHit, hitcats } from "../../../services/serviceWrapper";
 import Form from "../../../components/form/Form";
 import Xl8 from "../../../components/xl8/Xl8";
 import LabelledInput from "../../../components/labelledInput/LabelledInput";
+import RoleAuthenticator from "../../../context/roleAuthenticator/RoleAuthenticator";
 import { asArray } from "../../../utils/utils";
+import { ROLE } from "../../../utils/constants";
+import { manualHit, hitcats } from "../../../services/serviceWrapper";
 
 const CreateManualHit = props => {
   const cb = () => {};
@@ -34,7 +36,7 @@ const CreateManualHit = props => {
   }, []);
 
   return (
-    <>
+    <RoleAuthenticator roles={[ROLE.ADMIN, ROLE.HITMGR]} alt={<></>}>
       <Button variant="outline-danger" size="sm" onClick={handleShow}>
         <Xl8 xid="cmh001">Create Manual Hit</Xl8>
       </Button>
@@ -107,7 +109,7 @@ const CreateManualHit = props => {
           </Form>
         </Modal.Body>
       </Modal>
-    </>
+    </RoleAuthenticator>
   );
 };
 CreateManualHit.propTypes = {

--- a/src/pages/tools/Tools.js
+++ b/src/pages/tools/Tools.js
@@ -3,13 +3,52 @@ import Title from "../../components/title/Title";
 import Xl8 from "../../components/xl8/Xl8";
 import Main from "../../components/main/Main";
 import { Card, CardDeck } from "react-bootstrap";
-import { asArray, getEndpoint } from "../../utils/utils";
+import RoleAuthenticator from "../../context/roleAuthenticator/RoleAuthenticator";
+import { getEndpoint } from "../../utils/utils";
+import { ROLE } from "../../utils/constants";
 import { Link } from "@reach/router";
 import "./Tools.css";
 
 const Tools = props => {
-  const children = props.children?.props?.children;
-  const tiles = asArray(children).filter(child => child.props.hideTile !== true);
+  const tiles = [
+    {
+      name: <Xl8 xid="app001">Rules</Xl8>,
+      desc: <Xl8 xid="app002">View or edit rules for generating hits</Xl8>,
+      path: "rules",
+      icon: "fa-address-book-o",
+      roles: [ROLE.ADMIN, ROLE.RULEMGR]
+    },
+    {
+      name: <Xl8 xid="app003">Queries</Xl8>,
+      desc: <Xl8 xid="app004">View or edit queries of system data</Xl8>,
+      path: "queries",
+      icon: "fa-search",
+      roles: [ROLE.ADMIN, ROLE.QRYMGR]
+    },
+    {
+      name: <Xl8 xid="app005">Watchlist</Xl8>,
+      desc: <Xl8 xid="app006">View or add passenger and document watchlists</Xl8>,
+      path: "watchlist",
+      icon: "fa-user-secret",
+      roles: [ROLE.ADMIN, ROLE.WLMGR]
+    },
+    {
+      name: <Xl8 xid="app007">About</Xl8>,
+      desc: <Xl8 xid="app008">View system information details</Xl8>,
+      path: "about",
+      icon: "fa-info-circle",
+      roles: [
+        ROLE.ADMIN,
+        ROLE.PAXVWR,
+        ROLE.RULEMGR,
+        ROLE.CASEMGR,
+        ROLE.WLMGR,
+        ROLE.HITMGR,
+        ROLE.QRYMGR,
+        ROLE.FLIGHTVWR
+      ]
+    }
+  ];
 
   if (getEndpoint(props.location?.pathname) === "tools")
     return (
@@ -18,22 +57,23 @@ const Tools = props => {
 
         <Main className="full-cards">
           <CardDeck className="page-deck">
-            {tiles.map(info => {
-              const data = info.props;
+            {tiles.map(data => {
               return (
-                <Card className="page-tiles card-shadow" key={data.path}>
-                  <Link to={data.path} className="card-link">
-                    <Card.Body>
-                      <Card.Title className="nowrap">
-                        <i className={`fa fa-3x ${data.icon}`}></i>
-                      </Card.Title>
-                      <div className="card-overlay">{data.name}</div>
-                      <div className="card-description">
-                        <Card.Text>{data.desc}</Card.Text>
-                      </div>
-                    </Card.Body>
-                  </Link>
-                </Card>
+                <RoleAuthenticator alt={<></>} roles={data.roles}>
+                  <Card className="page-tiles card-shadow" key={data.path}>
+                    <Link to={data.path} className="card-link">
+                      <Card.Body>
+                        <Card.Title className="nowrap">
+                          <i className={`fa fa-3x ${data.icon}`}></i>
+                        </Card.Title>
+                        <div className="card-overlay">{data.name}</div>
+                        <div className="card-description">
+                          <Card.Text>{data.desc}</Card.Text>
+                        </div>
+                      </Card.Body>
+                    </Link>
+                  </Card>
+                </RoleAuthenticator>
               );
             })}
           </CardDeck>

--- a/src/pages/tools/queryrules/QRDetails.js
+++ b/src/pages/tools/queryrules/QRDetails.js
@@ -3,9 +3,11 @@ import Table from "../../../components/table/Table";
 import { querypax } from "../../../services/serviceWrapper";
 import Title from "../../../components/title/Title";
 import Xl8 from "../../../components/xl8/Xl8";
+import RoleAuthenticator from "../../../context/roleAuthenticator/RoleAuthenticator";
 import { Link } from "@reach/router";
 import { Container } from "react-bootstrap";
 import { asArray, getAge, alt, localeDateOnly } from "../../../utils/utils";
+import { ROLE } from "../../../utils/constants";
 
 const QRDetails = props => {
   const cb = function(result) {};
@@ -66,16 +68,12 @@ const QRDetails = props => {
 
   //TOOD - need a back button or some way to get back to the query/rule page that brought us here.
   return (
-    <Container fluid>
-      <Title title={<Xl8 xid="">Query Details</Xl8>}></Title>
-      <Table
-        data={data}
-        header={headers}
-        id="Query Details"
-        callback={cb}
-        key={key}
-      ></Table>
-    </Container>
+    <RoleAuthenticator roles={[ROLE.ADMIN, ROLE.QRYMGR]}>
+      <Container fluid>
+        <Title title={<Xl8 xid="">Query Details</Xl8>}></Title>
+        <Table data={data} header={headers} callback={cb} key={key}></Table>
+      </Container>
+    </RoleAuthenticator>
   );
 };
 

--- a/src/pages/tools/queryrules/QRModal.js
+++ b/src/pages/tools/queryrules/QRModal.js
@@ -5,9 +5,9 @@ import LabelledInput from "../../../components/labelledInput/LabelledInput";
 import Xl8 from "../../../components/xl8/Xl8";
 import { navigate } from "@reach/router";
 import { hasData, asArray, localeDateOnly } from "../../../utils/utils";
-import { QR, ACTION, CTX } from "../../../utils/constants";
+import { QR, ACTION, CTX, ROLE } from "../../../utils/constants";
 import { LookupContext } from "../../../context/data/LookupContext";
-
+import RoleAuthenticator from "../../../context/roleAuthenticator/RoleAuthenticator";
 import {
   hitcats,
   airportLookup,
@@ -785,7 +785,7 @@ const QRModal = props => {
             variant="outline-dark"
             onClick={onClose}
           >
-            <Xl8 xid="">Close</Xl8>
+            <Xl8 xid="qrm007">Close</Xl8>
           </Button>
           <Button
             type="button"
@@ -794,7 +794,7 @@ const QRModal = props => {
             variant="outline-dark"
             onClick={onClear}
           >
-            <Xl8 xid="">Clear</Xl8>
+            <Xl8 xid="QRM008">Clear</Xl8>
           </Button>
           <Button
             key="save"
@@ -803,17 +803,20 @@ const QRModal = props => {
             variant="outline-dark"
             onClick={onSave}
           >
-            <Xl8 xid="">Save</Xl8>
+            <Xl8 xid="qrm009">Save</Xl8>
           </Button>
-          <Button
-            key="run"
-            type="button"
-            className="m-2 outline-dark-outline"
-            variant="outline-dark"
-            onClick={onRun}
-          >
-            <Xl8 xid="">Run</Xl8>
-          </Button>
+
+          <RoleAuthenticator roles={[ROLE.ADMIN, ROLE.QRYMGR]} alt={<></>}>
+            <Button
+              key="run"
+              type="button"
+              className="m-2 outline-dark-outline"
+              variant="outline-dark"
+              onClick={onRun}
+            >
+              <Xl8 xid="qrm010">Run</Xl8>
+            </Button>
+          </RoleAuthenticator>
           {isEdit && (
             <Button
               key="delete"
@@ -822,7 +825,7 @@ const QRModal = props => {
               variant="outline-dark"
               onClick={onDelete}
             >
-              <Xl8 xid="">Delete</Xl8>
+              <Xl8 xid="qrm011">Delete</Xl8>
             </Button>
           )}
         </Modal.Footer>

--- a/src/pages/tools/queryrules/Queries.js
+++ b/src/pages/tools/queryrules/Queries.js
@@ -4,7 +4,8 @@ import Title from "../../../components/title/Title";
 import Xl8 from "../../../components/xl8/Xl8";
 import Main from "../../../components/main/Main";
 import { Button } from "react-bootstrap";
-import { QR, ACTION } from "../../../utils/constants";
+import { QR, ACTION, ROLE } from "../../../utils/constants";
+import RoleAuthenticator from "../../../context/roleAuthenticator/RoleAuthenticator";
 
 import { query } from "../../../services/serviceWrapper";
 import QRModal from "./QRModal";
@@ -75,25 +76,27 @@ const Queries = props => {
   };
 
   return (
-    <Main className="full">
-      <Title title={<Xl8 xid="q002">Queries</Xl8>} rightChild={button}></Title>
-      <Table
-        service={query.get}
-        callback={cb}
-        header={header}
-        key={`table${tablekey}`}
-      ></Table>
-      <QRModal
-        show={showModal}
-        onHide={closeModal}
-        callback={cb}
-        key={key}
-        data={record}
-        title={modalTitle}
-        id={id}
-        service={query}
-      />
-    </Main>
+    <RoleAuthenticator roles={[ROLE.ADMIN, ROLE.QRYMGR]}>
+      <Main className="full">
+        <Title title={<Xl8 xid="q002">Queries</Xl8>} rightChild={button}></Title>
+        <Table
+          service={query.get}
+          callback={cb}
+          header={header}
+          key={`table${tablekey}`}
+        ></Table>
+        <QRModal
+          show={showModal}
+          onHide={closeModal}
+          callback={cb}
+          key={key}
+          data={record}
+          title={modalTitle}
+          id={id}
+          service={query}
+        />
+      </Main>
+    </RoleAuthenticator>
   );
 };
 

--- a/src/pages/tools/queryrules/Rules.js
+++ b/src/pages/tools/queryrules/Rules.js
@@ -9,7 +9,8 @@ import { LookupContext } from "../../../context/data/LookupContext";
 
 import { rulesall, rule } from "../../../services/serviceWrapper";
 import { hasData, getEndpoint } from "../../../utils/utils";
-import { QR, ACTION, RULETAB } from "../../../utils/constants";
+import { QR, ACTION, RULETAB, ROLE } from "../../../utils/constants";
+import RoleAuthenticator from "../../../context/roleAuthenticator/RoleAuthenticator";
 import QRModal from "./QRModal";
 import "./QueryRules.css";
 
@@ -236,29 +237,36 @@ const Rules = props => {
   );
 
   return (
-    <Main className="full">
-      <Title
-        title={<Xl8 xid="rul006">Rules</Xl8>}
-        key="title"
-        leftChild={tabs}
-        leftCb={titleTabCallback}
-        rightChild={button}
-      ></Title>
-      <Table data={data} callback={cb} header={header} key={`table-${tablekey}`}></Table>
-      {showModal && (
-        <QRModal
-          show="true"
-          onHide={closeModal}
-          callback={modalCb}
-          mode={QR.RULE}
-          key={modalKey}
-          data={record}
-          title={modalTitle}
-          id={id}
-          service={rule}
-        />
-      )}
-    </Main>
+    <RoleAuthenticator roles={[ROLE.ADMIN, ROLE.RULEMGR]}>
+      <Main className="full">
+        <Title
+          title={<Xl8 xid="rul006">Rules</Xl8>}
+          key="title"
+          leftChild={tabs}
+          leftCb={titleTabCallback}
+          rightChild={button}
+        ></Title>
+        <Table
+          data={data}
+          callback={cb}
+          header={header}
+          key={`table-${tablekey}`}
+        ></Table>
+        {showModal && (
+          <QRModal
+            show="true"
+            onHide={closeModal}
+            callback={modalCb}
+            mode={QR.RULE}
+            key={modalKey}
+            data={record}
+            title={modalTitle}
+            id={id}
+            service={rule}
+          />
+        )}
+      </Main>
+    </RoleAuthenticator>
   );
 };
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -37,9 +37,9 @@ export const ROLE = {
   PAXVWR: "View Passenger",
   WLMGR: "Manage Watch List",
   RULEMGR: "Manage Rules",
-  SYSADMIN: "SysAdmin",
+  SYSADMIN: "SysAdmin", //TODO remove?
   HITMGR: "Manage Hits",
-  CASEMGR: "Manage Cases",
+  CASEMGR: "Manage Cases", //TODO remove?
   FLIGHTVWR: "View Flights",
   ANY: "Any"
 };


### PR DESCRIPTION
fixes ticket #275.

- [ ] View Passenger role Can still see QB card (cannot see the queries)
- [ ] View Passenger role Can still see RB card (cannot see the rules)
- [ ] View Passenger role Can still see watchlist
- [ ] View Passenger role can still see add to watchlist button
- [ ] View Passenger role can still see manual hit button
- [ ] Manage Watchlist role cannot use the add to watchlist button on passenger details (add to WL button might be broken altogether at the moment)
- [ ] Manage Watchlist role cannot use the add to watchlist button on passenger details
- [ ] users can set passenger status to reviewed without manage cases role