### PR TITLE
Changed groupBy icons to use font awesome

### DIFF
--- a/src/components/table/Table.js
+++ b/src/components/table/Table.js
@@ -200,8 +200,8 @@ const Table = props => {
                                   {props.disableGroupBy
                                     ? ""
                                     : column.isGrouped
-                                    ? "🛑"
-                                    : "👊 "}
+                                    ? <i className="fa fa-object-ungroup"></i>
+                                    : <i class="fa fa-object-group"></i>}
                                 </span>
                               ) : (
                                 ""


### PR DESCRIPTION
Would like to eventually mimic sortIcon function behaviour and feed it the column to determine type of icon returned rather than leaving the logic inside the table element itself. But this works for now.