### PR TITLE
Fix/datepickerlayout

### DIFF
--- a/src/components/filterForm2/FilterForm.css
+++ b/src/components/filterForm2/FilterForm.css
@@ -1,13 +1,19 @@
-.FormContainer {
-  /* min-height: var(--height-content); */
-}
-
 .filterform-container {
   margin-top: 15px;
   overflow-x: hidden;
   overflow-y: auto;
   height: calc(100vh - 80px);
   padding-right: 15px;
+}
+
+.filterform-container .react-calendar {
+  position: fixed;
+  top: auto;
+  line-height: 0.5rem;
+  width: 350px !important;
+  border-radius: 5px;
+  display: block;
+  max-width: unset;
 }
 
 .input:optional {

--- a/src/components/filterForm2/FilterForm.css
+++ b/src/components/filterForm2/FilterForm.css
@@ -4,6 +4,10 @@
 
 .filterform-container {
   margin-top: 15px;
+  overflow-x: hidden;
+  overflow-y: auto;
+  height: calc(100vh - 80px);
+  padding-right: 15px;
 }
 
 .input:optional {

--- a/src/components/sidenavContainer/SidenavContainer.scss
+++ b/src/components/sidenavContainer/SidenavContainer.scss
@@ -131,7 +131,7 @@ $transparent: #0082c3d9;
 .filter-bg {
   z-index: 5;
   background: linear-gradient(#40403f, #40403fe8, #40403f99),
-    url($background-image-url) no-repeat no-repeat;
+    url($background-image-url) no-repeat no-repeat fixed;
   background-position: -600px 0px;
   background-size: cover;
 }

--- a/src/components/sidenavContainer/SidenavContainer.scss
+++ b/src/components/sidenavContainer/SidenavContainer.scss
@@ -116,11 +116,10 @@ $transparent: #0082c3d9;
 .filter-fg-open {
   color: #f8f9fa;
   z-index: 10;
-  overflow: auto;
 }
 
 .filter-fg::-webkit-scrollbar-thumb {
-  border: 5px solid #40403f !important;
+  border: 3px solid #40403f !important;
   background-color: white;
   border-radius: 12px;
 }
@@ -146,6 +145,7 @@ hr {
   backdrop-filter: blur(2px);
   border-radius: 0.5rem;
   padding-bottom: 5px;
+  padding-right: 0px;
 }
 
 .notopmargin {

--- a/src/pages/vetting/Vetting.css
+++ b/src/pages/vetting/Vetting.css
@@ -1,19 +1,3 @@
-.dtp-vetting-upper > span > div > .react-calendar {
-  position: fixed;
-  top: auto;
-  line-height: 0.5rem;
-  width: 350px !important;
-  border-radius: 5px;
-  display: block;
-  max-width: unset;
-}
-
 .dtp-vetting-lower > span > div > .react-calendar {
-  position: fixed;
-  bottom: calc(0vh + 10px);
-  line-height: 0.5rem;
-  width: 350px !important;
-  border-radius: 5px;
-  display: block;
-  max-width: unset;
+  /* bottom: calc(0vh + 10px); */
 }

--- a/src/pages/vetting/Vetting.css
+++ b/src/pages/vetting/Vetting.css
@@ -1,19 +1,19 @@
 .dtp-vetting-upper > span > div > .react-calendar {
   position: fixed;
-  top: calc(100vh - 307px);
-  left: 231px;
+  top: auto;
   line-height: 0.5rem;
-  width: 320px !important;
+  width: 350px !important;
   border-radius: 5px;
   display: block;
+  max-width: unset;
 }
 
 .dtp-vetting-lower > span > div > .react-calendar {
   position: fixed;
   bottom: calc(0vh + 10px);
-  left: 231px;
   line-height: 0.5rem;
-  width: 320px !important;
+  width: 350px !important;
   border-radius: 5px;
   display: block;
+  max-width: unset;
 }


### PR DESCRIPTION
Datepicker was being clipped by the sidenav and forcing a horizontal scroll to see all of it. 

- Updated the layout to force the width to 350px so the month and day don't overlap
- Forced the parent container to display the horizontal overflow without scrolling
- repositioned the date popup to prevent it displaying on the side for mobile viewports
- Affects datepickers on Vetting, AuditLog, and ErrorLog pages.

fixes #360 