### PR TITLE
force read mode on logout

### DIFF
--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -42,7 +42,13 @@ const Header = () => {
 
   const logout = () => {
     userAction({ type: "logoff" });
+    action({ type: "read" });
 
+    navigate("/login");
+  };
+
+  // allow a 'false' logout for admins translating pages outside the authed/loggedin bundle
+  const pseudoLogout = () => {
     navigate("/login");
   };
 


### PR DESCRIPTION
force reset of live edit mode when the user logs out. This is in prep for the logout workaround ticket where we allow admins in live edit mode to "pseudo logout" so they can see and translate pages outside the authed bundle (TBD).