### PR TITLE
Fix for categories not displaying properly when just created on both …

### DIFF
--- a/src/pages/tools/queryrules/QRModal.js
+++ b/src/pages/tools/queryrules/QRModal.js
@@ -599,7 +599,7 @@ const QRModal = props => {
     const storedCcTypes = getLookupState(CTX.CCTYPES);
 
     // move to context.
-    if (hasData(storedCategories)) {
+    if (/*hasData(storedCategories)*/ false) { //Categories are perhaps small enough in amount that caching them is unnecessary?
       setCategories(storedCategories);
     } else {
       hitcats.get().then(res => {

--- a/src/pages/vetting/Vetting.js
+++ b/src/pages/vetting/Vetting.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useRef } from "react";
 import Table from "../../components/table/Table";
-import { cases, notetypes, usersemails, ruleCats } from "../../services/serviceWrapper";
+import {cases, notetypes, usersemails, hitcats} from "../../services/serviceWrapper";
 import Title from "../../components/title/Title";
 import Xl8 from "../../components/xl8/Xl8";
 import LabelledInput from "../../components/labelledInput/LabelledInput";
@@ -278,7 +278,7 @@ const Vetting = props => {
       setUsersEmails(emails);
     });
 
-    ruleCats.get().then(res => {
+    hitcats.get().then(res => {
       const options = asArray(res).map(hitCat => {
         return {
           label: hitCat.name,


### PR DESCRIPTION
After investigation getting rulecats/hitcats perform nearly identical function. Swapped from rulecats to hitcats on the vetting page to use non-archived hit categories endpoint.

This fixes #366 