### PR TITLE
Fix/flight history cards

### DIFF
--- a/src/components/cardWithTable/CardWithTable.js
+++ b/src/components/cardWithTable/CardWithTable.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Card, Table } from "react-bootstrap";
 import "./CardWithTable.scss";
-import { asArray, isShortText, getShortText } from "../../utils/utils";
+import { asArray, isShortText, getShortText, alt } from "../../utils/utils";
 import Overlay from "../overlay/Overlay";
 
 const CardWithTable = props => {
@@ -9,6 +9,7 @@ const CardWithTable = props => {
   const headers = props.headers || {}; //{key:value}
   const cb = props.callback ? props.callback : () => {}; //callback may not be passed as a prop
   const textDisplayLimit = 30;
+  const className = `${alt(props.className)} card-with-table`;
 
   const tableHeaders = Object.keys(headers).map(key => {
     return <th key={key}>{headers[key]}</th>;
@@ -35,7 +36,7 @@ const CardWithTable = props => {
   });
 
   return (
-    <Card className="card-with-table">
+    <Card className={className}>
       <Card.Header className="customized-card-header">
         {props.title || ""} <span className="row-count">{data.length}</span>
       </Card.Header>

--- a/src/components/chrometabs/ChromeTabs.css
+++ b/src/components/chrometabs/ChromeTabs.css
@@ -1,7 +1,6 @@
 .gtas-tabs {
   border: none;
   margin-bottom: 3px;
-  width: calc(100vw - 730px);
   flex-wrap: nowrap;
   overflow-x: auto;
   overflow-y: hidden;

--- a/src/components/segmentTable/SegmentTable.css
+++ b/src/components/segmentTable/SegmentTable.css
@@ -5,7 +5,7 @@
   padding: 10px 0px 10px 10px;
   border: 1px solid #0082c3;
   border-radius: 0.25rem;
-  height: calc(100vh - 128px);
+  height: calc(100vh - 110px);
 }
 
 .segment-table > .table-responsive {

--- a/src/components/tabs/Tabs.css
+++ b/src/components/tabs/Tabs.css
@@ -1,7 +1,7 @@
 .gtas-tabs {
   border: none;
   margin-bottom: 3px;
-  width: calc(100vw - 730px);
+  /* width: calc(100vw - 730px); */
   flex-wrap: nowrap;
   overflow-x: auto;
   overflow-y: hidden;

--- a/src/pages/paxDetail/PaxDetail.scss
+++ b/src/pages/paxDetail/PaxDetail.scss
@@ -7,7 +7,7 @@ $wco-blue: rgb(0, 119, 200);
 $transparent: rgba(0, 0, 0, 0.65);
 
 .paxdetail-container {
-  height: calc(100vh - 125px);
+  height: calc(100vh - 110px);
   overflow: auto;
 
   // -- for single page repositioning
@@ -21,7 +21,7 @@ $transparent: rgba(0, 0, 0, 0.65);
 .paxdetail-container-col {
   width: 100%;
   margin-left: 15px;
-  height: calc(100vh - 128px);
+  height: calc(100vh - 110px);
   overflow: auto;
 }
 
@@ -29,6 +29,14 @@ $transparent: rgba(0, 0, 0, 0.65);
   .paxdetail-container {
     .card-columns {
       column-count: 1 !important;
+
+      .pd-gridstack-2 {
+        max-height: unset !important;
+
+        .table-responsive {
+          max-height: calc((100vh - 190px) / 2) !important;
+        }
+      }
     }
   }
 }
@@ -37,6 +45,14 @@ $transparent: rgba(0, 0, 0, 0.65);
   .paxdetail-container {
     .card-columns {
       column-count: 2 !important;
+
+      .pd-gridstack-2 {
+        max-height: unset !important;
+
+        .table-responsive {
+          max-height: calc(100vh - 145px) !important;
+        }
+      }
     }
   }
 }
@@ -82,9 +98,6 @@ $transparent: rgba(0, 0, 0, 0.65);
 
 .paxdetail-container > .title > .left-span > .gtas-tabs > a {
   padding: 0.5rem 0.5rem;
-}
-
-.segment-table {
 }
 
 .filter-fg > .col > .table {

--- a/src/pages/paxDetail/flightHistory/FlightHistory.js
+++ b/src/pages/paxDetail/flightHistory/FlightHistory.js
@@ -45,16 +45,18 @@ const FlightHistory = props => {
   }, []);
 
   return (
-    <div className="one-column-container">
+    <div className="paxdetail-container">
       <CardColumns>
         <CardWithTable
           data={currentFlightHistory}
           headers={headers}
+          className="pd-gridstack-2 flex-grow-0"
           title={<Xl8 xid="fh009">Current Itinerary</Xl8>}
         />
         <CardWithTable
           data={fullTravelHistory}
           headers={headers}
+          className="pd-gridstack-2 flex-grow-1"
           title={<Xl8 xid="fh010">Total Flight History</Xl8>}
         />
       </CardColumns>


### PR DESCRIPTION
fixes the flight history tabs in 1 and 2 column layout. added flex so the more populated history table can spread out.

needs testing with a lot of data and various screen widths. Look at the other paxdetail pages as well to verify the css updates didn't the other column layouts.