### PR TITLE
Fix/pnr credit card dates

### DIFF
--- a/src/pages/paxDetail/pnr/PNR.js
+++ b/src/pages/paxDetail/pnr/PNR.js
@@ -2,7 +2,13 @@ import React from "react";
 import { Row, Col, Container } from "react-bootstrap";
 import SegmentTable from "../../../components/segmentTable/SegmentTable";
 import CardWithTable from "../../../components/cardWithTable/CardWithTable";
-import { asArray, hasData, localeDate, localeDateOnly } from "../../../utils/utils";
+import {
+  asArray,
+  hasData,
+  localeDate,
+  localeDateOnly,
+  localeMonthYear
+} from "../../../utils/utils";
 import Xl8 from "../../../components/xl8/Xl8";
 import { Link } from "@reach/router";
 
@@ -229,7 +235,7 @@ const PNR = props => {
   const creditCards = asArray(data.creditCards).map(ccData => {
     return {
       ...ccData,
-      expiration: localeDateOnly(ccData.expiration),
+      expiration: localeMonthYear(ccData.expiration),
       key: `FOP${ccData.number} `
     };
   });

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -176,6 +176,18 @@ export function localeMonthDayTime(val) {
   return new Date(val).toLocaleString(locale, options);
 }
 
+// Locale Month Year format (creditcard expiration dates)
+export const localeMonthYear = val => {
+  if (!hasData(val)) return "";
+
+  const locale = window.navigator.language;
+  const options = {
+    month: "2-digit",
+    year: "2-digit"
+  };
+  return new Date(val).toLocaleString(locale, options);
+};
+
 // Returns the day of the week for a given date string
 // WARNING: dates in the format yyyy-mm-dd with no timezone indicated are interpreted
 // as UTC dates, which will NOT equal the locale date for the hours where the UTC timezone


### PR DESCRIPTION
Added a locale date formatter for MM/YY credit card expiration dates on the PNR tab. for YMD format countries like China, it correctly displays as YY/MM.