### PR TITLE
Flights - fix the airport filter fxn

### DIFF
--- a/src/pages/flights/Flights.js
+++ b/src/pages/flights/Flights.js
@@ -82,7 +82,7 @@ const Flights = props => {
         if (name === "destinationAirports" || name === "originAirports") {
           // retrieve raw comma- or whitespace-separated text, convert to array, remove empties.
           const airports = fieldscopy[name]
-            .replace(",", " ")
+            .replace(/[,]/g, " ")
             .split(" ")
             .filter(Boolean);
           paramObject[name] = [...new Set(airports)]; // scrub duplicate vals


### PR DESCRIPTION
fixed the replace function to use a regex when constructing the airport filter array.

Accepts space separated and comma separated codes. Test with strings with combinations of separators and airports like:
`LHR,, DOH FRA IAD`
`IAD   DOH   LHR`
`IAD,DOH,LHR`
`,,  IAD,,, DOH    `
etc

fixes #443 