### PR TITLE
fix PNR Itinerary flight leg order

### DIFF
--- a/src/pages/paxDetail/pnr/PNR.js
+++ b/src/pages/paxDetail/pnr/PNR.js
@@ -1,8 +1,9 @@
 import React from "react";
-import { Row, Col, Container } from "react-bootstrap";
+import { Row, Col } from "react-bootstrap";
 import SegmentTable from "../../../components/segmentTable/SegmentTable";
 import CardWithTable from "../../../components/cardWithTable/CardWithTable";
 import {
+  alt,
   asArray,
   hasData,
   localeDate,
@@ -18,9 +19,6 @@ const PNR = props => {
     hasData(data.version) ? `(Version: ${data.version})` : ""
   }`;
 
-  const sortFlightByEta = (flight1, flight2) => {
-    return flight2.eta - flight1.eta;
-  };
   const addLinkToFlight = flight => {
     //Only prime flights need a link
     const isPrimeFlight = !hasData(flight.bookingDetailId);
@@ -206,19 +204,17 @@ const PNR = props => {
     }
   };
   const rawPnrSegments = asArray(data.segmentList);
-  const itinerary = asArray(data.flightLegs)
-    .sort(sortFlightByEta)
-    .map((leg, index) => {
-      return {
-        leg: index + 1,
-        flightNumber: addLinkToFlight(leg),
-        origin: leg.originAirport,
-        destination: leg.destinationAirport,
-        departure: localeDate(leg.etd),
-        arrival: localeDate(leg.eta),
-        key: `TVL${leg.originAirport} `
-      };
-    });
+  const itinerary = asArray(data.flightLegs).map((leg, index) => {
+    return {
+      leg: +alt(leg.legNumber, 0) + 1,
+      flightNumber: addLinkToFlight(leg),
+      origin: leg.originAirport,
+      destination: leg.destinationAirport,
+      departure: localeDate(leg.etd),
+      arrival: localeDate(leg.eta),
+      key: `TVL${leg.originAirport} `
+    };
+  });
 
   const passengers = asArray(data.passengers).map(passenger => {
     return {


### PR DESCRIPTION
fix #523 - remove the extra sort function on the flight legs and use the legNumber field in the dataset.

Issue was that the legs were sorted in the reverse order from the latest leg to the earliest. 