### PR TITLE
Fix/hit aggregate sort

### DIFF
--- a/src/components/hitsBadge/HitsBadge.css
+++ b/src/components/hitsBadge/HitsBadge.css
@@ -10,3 +10,19 @@
   width: 33%;
   text-align: center;
 }
+
+.hits-flag {
+  margin-right: 3px;
+}
+
+.hits-flag.high {
+  color: red;
+}
+
+.hits-flag.med {
+  color: orange;
+}
+
+.hits-flag.low {
+  color: #e2d402;
+}

--- a/src/components/hitsBadge/HitsBadge.css
+++ b/src/components/hitsBadge/HitsBadge.css
@@ -1,0 +1,12 @@
+.hits-table {
+  justify-content: space-between;
+  display: flex;
+  align-items: baseline;
+  margin-left: 5px;
+  margin-right: 5px;
+}
+
+.hits-cell {
+  width: 33%;
+  text-align: center;
+}

--- a/src/components/hitsBadge/HitsBadge.js
+++ b/src/components/hitsBadge/HitsBadge.js
@@ -1,0 +1,45 @@
+import React from "react";
+import { localeMonthDayTime, hasData, alt } from "../../utils/utils";
+import { Row } from "react-bootstrap";
+import "./HitsBadge.css";
+
+const HitsBadge = props => {
+  return (
+    <span className="hits-table">
+      <span className="hits-cell">
+        {props.high > 0 && (
+          <>
+            <i className="fa fa-flag" style={{ color: "red" }} title="top severity"></i>
+            {props.high}
+          </>
+        )}
+      </span>
+      <span className="hits-cell">
+        {props.med > 0 && (
+          <>
+            <i
+              className="fa fa-flag"
+              style={{ color: "orange" }}
+              title="high severity"
+            ></i>
+            {props.med}
+          </>
+        )}
+      </span>
+      <span className="hits-cell">
+        {props.low > 0 && (
+          <>
+            <i
+              className="fa fa-flag"
+              style={{ color: "#FCF300" }}
+              title="normal severity"
+            ></i>
+            {props.low}
+          </>
+        )}
+      </span>
+    </span>
+  );
+};
+
+export default HitsBadge;

--- a/src/components/hitsBadge/HitsBadge.js
+++ b/src/components/hitsBadge/HitsBadge.js
@@ -9,7 +9,7 @@ const HitsBadge = props => {
       <span className="hits-cell">
         {props.high > 0 && (
           <>
-            <i className="fa fa-flag" style={{ color: "red" }} title="top severity"></i>
+            <i className="fa fa-flag hits-flag high" title="top severity"></i>
             {props.high}
           </>
         )}
@@ -17,11 +17,7 @@ const HitsBadge = props => {
       <span className="hits-cell">
         {props.med > 0 && (
           <>
-            <i
-              className="fa fa-flag"
-              style={{ color: "orange" }}
-              title="high severity"
-            ></i>
+            <i className="fa fa-flag hits-flag med" title="high severity"></i>
             {props.med}
           </>
         )}
@@ -29,11 +25,7 @@ const HitsBadge = props => {
       <span className="hits-cell">
         {props.low > 0 && (
           <>
-            <i
-              className="fa fa-flag"
-              style={{ color: "#FCF300" }}
-              title="normal severity"
-            ></i>
+            <i className="fa fa-flag hits-flag low" title="normal severity"></i>
             {props.low}
           </>
         )}

--- a/src/pages/flightPax/FlightPax.js
+++ b/src/pages/flightPax/FlightPax.js
@@ -3,7 +3,6 @@ import Table from "../../components/table/Table";
 import Title from "../../components/title/Title";
 import Xl8 from "../../components/xl8/Xl8";
 import FlightBadge from "../../components/flightBadge/FlightBadge";
-// import LabelledInput from "../../components/labelledInput/LabelledInput";
 import SidenavContainer from "../../components/sidenavContainer/SidenavContainer";
 import CountdownBadge from "../../components/countdownBadge/CountdownBadge";
 import HitsBadge from "../../components/hitsBadge/HitsBadge";
@@ -18,7 +17,8 @@ import {
   getAge,
   alt,
   localeDateOnly,
-  localeDate,
+  aboveZero,
+  lpad5,
   sortableDate
 } from "../../utils/utils";
 import { ROLE } from "../../utils/constants";
@@ -60,16 +60,38 @@ const FlightPax = props => {
       item.dobAge = `${alt(displayDobDate)} ${item.age}`;
       item.rulehit = item.onRuleHitList ? 1 : "";
       item.watchhit = item.onWatchList ? 1 : "";
-      item.hitCounts = `${item.highPrioHitCount || 0}${item.medPrioHitCount ||
-        0}${item.lowPrioHitCount || 0}`;
+      item.hitCounts = `${lpad5(item.highPrioHitCount)}:${lpad5(
+        item.medPrioHitCount
+      )}:${lpad5(item.lowPrioHitCount)}`;
 
       item.aggregateHitsCount = {
         low: item.lowPrioHitCount,
         med: item.medPrioHitCount,
         high: item.highPrioHitCount
       };
+
       return item;
     });
+  };
+
+  // For an array of hitCounts strings for all travelers in a co-traveler group we get the sum of all hits.
+  // This aggregation allows us to sort the hitCounts col by severity using the colon-delimited strings
+  // and still capture the total number of hits when the table is grouped by reservation number (co-travelers).
+  // So for a co-traveler hit array like this:
+  //    ["00002:00003:00000", "00000:00002:00000", "00000:00000:00001"]
+  // where each string represents the hits for a single co-traveler, we sum all the numeric sections
+  const sumCotravelerHits = cotravelerHits => {
+    const groupHitTotal = cotravelerHits.reduce(
+      (totalHitsAccumulator, hitCountString) => {
+        const sum = hitCountString
+          .split(":")
+          .reduce((currentPaxTotal, hitSection) => +currentPaxTotal + +hitSection, 0);
+        return +sum + totalHitsAccumulator;
+      },
+      0
+    );
+
+    return groupHitTotal;
   };
 
   const hitHeaders = [
@@ -79,7 +101,7 @@ const FlightPax = props => {
       Header: ["fp011", "Rule Hits"],
       disableGroupBy: true,
       aggregate: "sum",
-      Aggregated: ({ value }) => `${value} Hits`
+      Aggregated: ({ value }) => aboveZero(value)
     },
     {
       Accessor: "watchlistHitCount",
@@ -87,7 +109,7 @@ const FlightPax = props => {
       Header: ["fp012", "Watchlist Hits"],
       disableGroupBy: true,
       aggregate: "sum",
-      Aggregated: ({ value }) => `${value} Hits`
+      Aggregated: ({ value }) => aboveZero(value)
     },
     {
       Accessor: "graphHitCount",
@@ -95,7 +117,7 @@ const FlightPax = props => {
       Header: ["fp022", "Graph Hits"],
       disableGroupBy: true,
       aggregate: "sum",
-      Aggregated: ({ value }) => `${value} Hits`
+      Aggregated: ({ value }) => aboveZero(value)
     },
     {
       Accessor: "fuzzyHitCount",
@@ -103,7 +125,7 @@ const FlightPax = props => {
       Header: ["fp023", "Partial Hits"],
       disableGroupBy: true,
       aggregate: "sum",
-      Aggregated: ({ value }) => `${value} Hits`
+      Aggregated: ({ value }) => aboveZero(value)
     },
     {
       Accessor: "manualHitCount",
@@ -111,7 +133,7 @@ const FlightPax = props => {
       Header: ["fp024", "Manual Hits"],
       disableGroupBy: true,
       aggregate: "sum",
-      Aggregated: ({ value }) => `${value} Hits`
+      Aggregated: ({ value }) => aboveZero(value)
     },
     {
       Accessor: "externalHitCount",
@@ -119,27 +141,29 @@ const FlightPax = props => {
       Header: ["fp025", "External Hits"],
       disableGroupBy: true,
       aggregate: "sum",
-      Aggregated: ({ value }) => `${value} Hits`
+      Aggregated: ({ value }) => aboveZero(value)
     }
   ];
 
-  const aggregateHitHeader = {
-    Accessor: "hitCounts",
-    Xl8: true,
-    Header: ["fp026", "Hit Aggregates"],
-    disableGroupBy: true,
-    aggregate: "sum",
-    Aggregated: ({ value }) => `${value} Hits`,
-    Cell: ({ row }) => (
-      <HitsBadge
-        high={row.original.aggregateHitsCount.high}
-        med={row.original.aggregateHitsCount.med}
-        low={row.original.aggregateHitsCount.low}
-      ></HitsBadge>
-    )
-  };
+  const aggregateHitHeader = [
+    {
+      Accessor: "hitCounts",
+      Xl8: true,
+      Header: ["fp026", "Hit Aggregates"],
+      disableGroupBy: true,
+      aggregate: sumCotravelerHits,
+      Aggregated: ({ value }) => aboveZero(value),
+      Cell: ({ row }) => (
+        <HitsBadge
+          high={row.original.aggregateHitsCount.high}
+          med={row.original.aggregateHitsCount.med}
+          low={row.original.aggregateHitsCount.low}
+        ></HitsBadge>
+      )
+    }
+  ];
 
-  const arrayHeaderFixer = tab !== "hits" ? [aggregateHitHeader] : hitHeaders;
+  const arrayHeaderFixer = tab !== "hits" ? aggregateHitHeader : hitHeaders;
   const headers = [
     ...arrayHeaderFixer,
     {
@@ -165,8 +189,7 @@ const FlightPax = props => {
         );
       },
       disableGroupBy: true,
-      aggregate: "count",
-      Aggregated: ({}) => ``
+      Aggregated: () => ``
     },
     {
       Accessor: "firstName",
@@ -187,8 +210,7 @@ const FlightPax = props => {
       Header: ["fp018", "DOB"],
       Cell: ({ row }) => <div>{row.original.dobAge}</div>,
       disableGroupBy: true,
-      aggregate: "count",
-      Aggregated: ({}) => ``
+      Aggregated: () => ``
     },
     {
       Accessor: "docNumber",
@@ -286,8 +308,6 @@ const FlightPax = props => {
               ></CountdownBadge>
             </div>
             <br />
-            {/* { label: <Xl8 xid="pd008">First Name</Xl8>, value: res.firstName },
-      { label: <Xl8 xid="pd009">Middle Name</Xl8>, value: res.middleName }, */}
 
             <table class="table table-sm table-borderless">
               <tbody>

--- a/src/pages/flightPax/FlightPax.js
+++ b/src/pages/flightPax/FlightPax.js
@@ -60,10 +60,9 @@ const FlightPax = props => {
       item.dobAge = `${alt(displayDobDate)} ${item.age}`;
       item.rulehit = item.onRuleHitList ? 1 : "";
       item.watchhit = item.onWatchList ? 1 : "";
-      item.hitCounts = `${item.lowPrioHitCount || 0}${item.medPrioHitCount ||
-        0}${item.highPrioHitCount || 0}`;
-      item.totalHitCounts =
-        item.lowPrioHitCount + item.medPrioHitCount + item.highPrioHitCount;
+      item.hitCounts = `${item.highPrioHitCount || 0}${item.medPrioHitCount ||
+        0}${item.lowPrioHitCount || 0}`;
+
       item.aggregateHitsCount = {
         low: item.lowPrioHitCount,
         med: item.medPrioHitCount,
@@ -125,53 +124,21 @@ const FlightPax = props => {
   ];
 
   const aggregateHitHeader = {
-    Accessor: "totalHitCounts",
+    Accessor: "hitCounts",
     Xl8: true,
     Header: ["fp026", "Hit Aggregates"],
     disableGroupBy: true,
     aggregate: "sum",
     Aggregated: ({ value }) => `${value} Hits`,
-    Cell: ({ row }) => {
-      return (
-        <span
-          style={{
-            "justify-content": "space-between",
-            display: "flex",
-            "align-items": "baseline",
-            marginLeft: "5px",
-            marginRight: "5px"
-          }}
-        >
-          {row.original.aggregateHitsCount.low > 0 && (
-            <span>
-              <i
-                className="fa fa-flag"
-                style={{ color: "#FCF300" }}
-                title="normal severity"
-              ></i>
-              {row.original.aggregateHitsCount.low}
-            </span>
-          )}
-          {row.original.aggregateHitsCount.med > 0 && (
-            <span>
-              <i
-                className="fa fa-flag"
-                style={{ color: "orange" }}
-                title="high severity"
-              ></i>
-              {row.original.aggregateHitsCount.med}
-            </span>
-          )}
-          {row.original.aggregateHitsCount.high > 0 && (
-            <span>
-              <i className="fa fa-flag" style={{ color: "red" }} title="top severity"></i>{" "}
-              {row.original.aggregateHitsCount.high}
-            </span>
-          )}
-        </span>
-      );
-    }
+    Cell: ({ row }) => (
+      <HitsBadge
+        high={row.original.aggregateHitsCount.high}
+        med={row.original.aggregateHitsCount.med}
+        low={row.original.aggregateHitsCount.low}
+      ></HitsBadge>
+    )
   };
+
   const arrayHeaderFixer = tab !== "hits" ? [aggregateHitHeader] : hitHeaders;
   const headers = [
     ...arrayHeaderFixer,

--- a/src/pages/flightPax/FlightPax.js
+++ b/src/pages/flightPax/FlightPax.js
@@ -6,10 +6,11 @@ import FlightBadge from "../../components/flightBadge/FlightBadge";
 // import LabelledInput from "../../components/labelledInput/LabelledInput";
 import SidenavContainer from "../../components/sidenavContainer/SidenavContainer";
 import CountdownBadge from "../../components/countdownBadge/CountdownBadge";
-import { Col, Tabs, Tab } from "react-bootstrap";
+import HitsBadge from "../../components/hitsBadge/HitsBadge";
 import Main from "../../components/main/Main";
 import RoleAuthenticator from "../../context/roleAuthenticator/RoleAuthenticator";
 import { Link } from "@reach/router";
+
 import { flightPassengers } from "../../services/serviceWrapper";
 import {
   asArray,
@@ -21,6 +22,7 @@ import {
   sortableDate
 } from "../../utils/utils";
 import { ROLE } from "../../utils/constants";
+import { Col, Tabs, Tab } from "react-bootstrap";
 import "./FlightPax.css";
 
 const FlightPax = props => {
@@ -34,12 +36,18 @@ const FlightPax = props => {
   const flightData = hasData(props.location.state?.data) ? props.location.state.data : {};
 
   const hasAnyHits = item => {
-    if (item.watchlistHitCount > 0 || item.manualHitCount > 0 || item.fuzzyHitCount > 0 || item.ruleHitCount > 0
-        || item.graphHitCount > 0 || item.externalHitCount > 0) {
+    if (
+      item.watchlistHitCount > 0 ||
+      item.manualHitCount > 0 ||
+      item.fuzzyHitCount > 0 ||
+      item.ruleHitCount > 0 ||
+      item.graphHitCount > 0 ||
+      item.externalHitCount > 0
+    ) {
       return true;
     }
     return false;
-  }
+  };
 
   const parseData = data => {
     return asArray(data).map(item => {
@@ -54,7 +62,8 @@ const FlightPax = props => {
       item.watchhit = item.onWatchList ? 1 : "";
       item.hitCounts = `${item.lowPrioHitCount || 0}${item.medPrioHitCount ||
         0}${item.highPrioHitCount || 0}`;
-      item.totalHitCounts = item.lowPrioHitCount+item.medPrioHitCount+item.highPrioHitCount;
+      item.totalHitCounts =
+        item.lowPrioHitCount + item.medPrioHitCount + item.highPrioHitCount;
       item.aggregateHitsCount = {
         low: item.lowPrioHitCount,
         med: item.medPrioHitCount,
@@ -120,7 +129,7 @@ const FlightPax = props => {
     Xl8: true,
     Header: ["fp026", "Hit Aggregates"],
     disableGroupBy: true,
-    aggregate: 'sum',
+    aggregate: "sum",
     Aggregated: ({ value }) => `${value} Hits`,
     Cell: ({ row }) => {
       return (

--- a/src/pages/flights/Flights.js
+++ b/src/pages/flights/Flights.js
@@ -14,7 +14,7 @@ import { UserContext } from "../../context/user/UserContext";
 
 import { Link } from "@reach/router";
 import { flights } from "../../services/serviceWrapper";
-import { hasData, alt, localeDate, asArray, aboveZero } from "../../utils/utils";
+import { hasData, alt, localeDate, asArray, aboveZero, lpad5 } from "../../utils/utils";
 import { TIME, ROLE } from "../../utils/constants";
 import { Col, Tabs, Tab } from "react-bootstrap";
 import "./Flights.css";
@@ -72,10 +72,9 @@ const Flights = props => {
       item.externalHitCount = aboveZero(item.externalHitCount);
       item.manualHitCount = aboveZero(item.manualHitCount);
 
-      item.hitCounts = `${alt(item.highPrioHitCount, 0)}${alt(
-        item.medPrioHitCount,
-        0
-      )}${alt(item.lowPrioHitCount, 0)}`;
+      item.hitCounts = `${lpad5(item.highPrioHitCount)}:${lpad5(
+        item.medPrioHitCount
+      )}:${lpad5(item.lowPrioHitCount)}`;
 
       item.aggregateHitsCount = {
         low: item.lowPrioHitCount,
@@ -93,8 +92,7 @@ const Flights = props => {
     setAllData(alt(parsedAll, []));
     setHitData(alt(parsedHits, []));
 
-    const newkey = tablekey + 1;
-    setTablekey(newkey);
+    setTablekey(tablekey + 1);
   };
 
   //TODO: refactor
@@ -126,8 +124,6 @@ const Flights = props => {
 
     return "?request=" + encodeURIComponent(JSON.stringify(paramObject));
   };
-
-  const now = new Date();
 
   const aggregateHitHeader = {
     Accessor: "hitCounts",
@@ -163,7 +159,7 @@ const Flights = props => {
       Cell: ({ row }) => (
         <CountdownBadge
           future={row.original.timer}
-          baseline={now}
+          baseline={new Date()}
           direction={row.original.direction}
         ></CountdownBadge>
       )

--- a/src/pages/flights/Flights.js
+++ b/src/pages/flights/Flights.js
@@ -6,6 +6,7 @@ import FilterForm from "../../components/filterForm2/FilterForm";
 import Main from "../../components/main/Main";
 import SidenavContainer from "../../components/sidenavContainer/SidenavContainer";
 import CountdownBadge from "../../components/countdownBadge/CountdownBadge";
+import HitsBadge from "../../components/hitsBadge/HitsBadge";
 
 import Xl8 from "../../components/xl8/Xl8";
 import RoleAuthenticator from "../../context/roleAuthenticator/RoleAuthenticator";
@@ -13,7 +14,7 @@ import { UserContext } from "../../context/user/UserContext";
 
 import { Link } from "@reach/router";
 import { flights } from "../../services/serviceWrapper";
-import { hasData, alt, localeDate, asArray } from "../../utils/utils";
+import { hasData, alt, localeDate, asArray, aboveZero } from "../../utils/utils";
 import { TIME, ROLE } from "../../utils/constants";
 import { Col, Tabs, Tab } from "react-bootstrap";
 import "./Flights.css";
@@ -35,12 +36,18 @@ const Flights = props => {
   const [tableState, setTableState] = useState(initTableState);
 
   const hasAnyHits = item => {
-    if (item.listHitCount > 0 || item.manualHitCount > 0 || item.fuzzyHitCount > 0 || item.ruleHitCount > 0
-        || item.graphHitCount > 0 || item.externalHitCount > 0) {
+    if (
+      item.listHitCount > 0 ||
+      item.manualHitCount > 0 ||
+      item.fuzzyHitCount > 0 ||
+      item.ruleHitCount > 0 ||
+      item.graphHitCount > 0 ||
+      item.externalHitCount > 0
+    ) {
       return true;
     }
     return false;
-  }
+  };
 
   const setDataWrapper = (data, retainState) => {
     if (!retainState) setTableState(initTableState);
@@ -55,18 +62,21 @@ const Flights = props => {
         item.sendRowToLink = `/gtas/flightpax/${item.id}`;
 
       const severity = alt(item.ruleHitCount, 0) + alt(item.listHitCount, 0);
-      item.severity = severity > 0 ? severity : "";
+      item.severity = aboveZero(severity);
 
       //Display null on hitcounts that are 0
-      if(item.listHitCount === 0) {item.listHitCount=""};
-      if(item.ruleHitCount === 0) {item.ruleHitCount=""};
-      if(item.graphHitCount === 0) {item.graphHitCount=""};
-      if(item.fuzzyHitCount === 0) {item.fuzzyHitCount=""};
-      if(item.externalHitCount === 0) {item.externalHitCount=""};
-      if(item.manualHitCount === 0) {item.manualHitCount=""};
+      item.listHitCount = aboveZero(item.listHitCount);
+      item.ruleHitCount = aboveZero(item.ruleHitCount);
+      item.graphHitCount = aboveZero(item.graphHitCount);
+      item.fuzzyHitCount = aboveZero(item.fuzzyHitCount);
+      item.externalHitCount = aboveZero(item.externalHitCount);
+      item.manualHitCount = aboveZero(item.manualHitCount);
 
-      item.hitCounts = `${item.lowPrioHitCount || 0}${item.medPrioHitCount ||
-      0}${item.highPrioHitCount || 0}`;
+      item.hitCounts = `${alt(item.highPrioHitCount, 0)}${alt(
+        item.medPrioHitCount,
+        0
+      )}${alt(item.lowPrioHitCount, 0)}`;
+
       item.aggregateHitsCount = {
         low: item.lowPrioHitCount,
         med: item.medPrioHitCount,
@@ -126,42 +136,11 @@ const Flights = props => {
     disableGroupBy: true,
     Cell: ({ row }) => {
       return (
-          <span
-              style={{
-                "justify-content": "space-between",
-                display: "flex",
-                "align-items": "baseline",
-                marginLeft: "5px",
-                marginRight: "5px"
-              }}
-          >
-          {row.original.aggregateHitsCount.low > 0 && (
-              <span>
-              <i
-                  className="fa fa-flag"
-                  style={{ color: "#FCF300" }}
-                  title="normal severity"
-              ></i>
-                {row.original.aggregateHitsCount.low}
-            </span>
-          )}
-            {row.original.aggregateHitsCount.med > 0 && (
-                <span>
-              <i
-                  className="fa fa-flag"
-                  style={{ color: "orange" }}
-                  title="high severity"
-              ></i>
-                  {row.original.aggregateHitsCount.med}
-            </span>
-            )}
-            {row.original.aggregateHitsCount.high > 0 && (
-                <span>
-              <i className="fa fa-flag" style={{ color: "red" }} title="top severity"></i>{" "}
-                  {row.original.aggregateHitsCount.high}
-            </span>
-            )}
-        </span>
+        <HitsBadge
+          high={row.original.aggregateHitsCount.high}
+          med={row.original.aggregateHitsCount.med}
+          low={row.original.aggregateHitsCount.low}
+        ></HitsBadge>
       );
     }
   };
@@ -172,7 +151,7 @@ const Flights = props => {
     { Accessor: "graphHitCount", Xl8: true, Header: ["fl015", "Graph Hits"] },
     { Accessor: "fuzzyHitCount", Xl8: true, Header: ["fl016", "Partial Hits"] },
     { Accessor: "externalHitCount", Xl8: true, Header: ["fl017", "External Hits"] },
-    { Accessor: "manualHitCount", Xl8: true, Header: ["fl023", "Manual Hits"] },
+    { Accessor: "manualHitCount", Xl8: true, Header: ["fl023", "Manual Hits"] }
   ];
 
   const arrayHeaderFixer = tab !== "hits" ? [aggregateHitHeader] : hitHeaders;
@@ -201,7 +180,7 @@ const Flights = props => {
       Header: ["fl011", "Departure"],
       Cell: ({ row }) => localeDate(row.original.etd)
     },
-      ...arrayHeaderFixer,
+    ...arrayHeaderFixer,
     {
       Accessor: "passengerCount",
       Xl8: true,

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -46,7 +46,6 @@ export const ROLE = {
   RULEMGR: "Manage Rules",
   SYSADMIN: "SysAdmin", //TODO remove?
   HITMGR: "Manage Hits",
-  // CASEMGR: "Manage Cases", //TODO remove?
   FLIGHTVWR: "View Flights",
   ANY: "Any"
 };

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -225,6 +225,10 @@ export function getParamList(fields) {
   return params;
 }
 
+export const aboveZero = (num, fallback) => {
+  return !isNaN(+num) && +num > 0 ? +num : fallback || "";
+};
+
 export const alt = (str, fallback) => {
   return hasData(str) && str !== "Invalid Date" ? str : fallback || "";
 };

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -353,3 +353,9 @@ export const watchlistDateFormat = input => {
 
   return `${year}-${month}-${day}`;
 };
+
+export const lpad5 = val => {
+  return alt(val, 0)
+    .toString()
+    .padStart(5, "0");
+};


### PR DESCRIPTION
fixes #536 
Fixed sort logic on Flights and Flightpax to sort by severity
Added a HitsBadge component for aligning hits flags in columns by severity
Moved css to a separate file
darkened the yellow on the low severity hits flag for visibility
Added an aggregate function to restore the hit count grouping that I broke with the severity sort fix.
Removed the word "Hits" from the aggregate values. (We can add it back but it has to be translatable)