### PR TITLE
Fix/historical hits

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -335,6 +335,11 @@ li .rtf--ab__c button[variant="rtf-red"] {
   padding: 15px;
 }
 
+.rtf--mb__c {
+  padding: unset !important;
+  margin: unset !important;
+}
+
 .table td {
   vertical-align: middle !important;
 }

--- a/src/pages/paxDetail/apis/APIS.js
+++ b/src/pages/paxDetail/apis/APIS.js
@@ -59,7 +59,7 @@ const APIS = props => {
         <CardWithTable
           data={passengersOnReservation}
           headers={headers.passengersOnReservation}
-          title={<Xl8 xid="apis004">Passenger on Reservation</Xl8>}
+          title={<Xl8 xid="apis004">Passengers on Reservation</Xl8>}
         />
       </CardColumns>
     </Main>

--- a/src/pages/paxDetail/apis/APIS.js
+++ b/src/pages/paxDetail/apis/APIS.js
@@ -10,14 +10,14 @@ const APIS = props => {
   const data = hasData(props.data) ? props.data : {};
   const headers = {
     bags: {
-      bagId: <Xl8 xid="apis005">Bag Id</Xl8>
+      bagId: <Xl8 xid="apis005">Bag ID</Xl8>
     },
     phoneNumbers: {
       number: <Xl8 xid="apis006">Phone Number</Xl8>
     },
     passengersOnReservation: {
       lastName: <Xl8 xid="apis007">Last Name</Xl8>,
-      firstName: <Xl8 xid="apis008">first Name</Xl8>,
+      firstName: <Xl8 xid="apis008">First Name</Xl8>,
       middleName: <Xl8 xid="apis009">Middle Name</Xl8>,
       passengerType: <Xl8 xid="apis010">Type</Xl8>,
       residencyCountry: <Xl8 xid="apis011">Residence</Xl8>,

--- a/src/pages/paxDetail/summary/Summary.js
+++ b/src/pages/paxDetail/summary/Summary.js
@@ -53,7 +53,7 @@ const Summary = props => {
       category: <Xl8 xid="sum026">Category</Xl8>,
       passengerDocNumber: <Xl8 xid="sum027">Document Number</Xl8>,
       ruleConditions: <Xl8 xid="sum028">Conditions</Xl8>,
-      flightDate: <Xl8 xid="sum029">Flight ID</Xl8>,
+      date: <Xl8 xid="sum029">Flight Date</Xl8>,
       flightPaxLink: <Xl8 xid="sum030">Info</Xl8>
     }
   };
@@ -115,13 +115,17 @@ const Summary = props => {
 
   const fetchHistoricalHitsData = () => {
     historicalHits.get(props.paxId).then(res => {
-      const parsedData = asArray(res).map(hit => {
-        return {
-          ...hit,
-          flightPaxLink: getLinkToPaxDetails(hit),
-          ruleConditions: formatRuleConditions(hit.ruleConditions)
-        };
-      });
+      const parsedData = asArray(res)
+        .map(hit => {
+          return {
+            ...hit,
+            date: localeDate(hit.flightDate),
+            flightPaxLink: getLinkToPaxDetails(hit),
+            ruleConditions: formatRuleConditions(hit.ruleConditions)
+          };
+        })
+        .sort((a, b) => b.flightDate - a.flightDate);
+
       setPaxHistoricalHits(parsedData);
     });
   };

--- a/src/pages/paxDetail/summary/Summary.js
+++ b/src/pages/paxDetail/summary/Summary.js
@@ -157,7 +157,7 @@ const Summary = props => {
     paxEventNotesHistory.get(props.paxId, true).then(res => {
       const notesData = res.paxNotes
         ?.map(note => {
-          const type = (note.noteTypes || []).map(t => {
+          const type = (note.noteType || []).map(t => {
             return t.noteType;
           });
           return {


### PR DESCRIPTION
Fixes #547 , (there is another historical hits ticket for a separate issue)

Fixed a bug that prevented the note category from showing in the Prior Event Notes card on PaxDetail Summary.
Fixed the Flight Date column and data in the Historical Hits card
Reduced the fab clickable area on the main button to just the button itself. It was previously an extra 20px around it and it was blocking links on the paxdetail cards. 