### PR TITLE
fix flight legs not displaying field values

### DIFF
--- a/src/components/raqb/constants.js
+++ b/src/components/raqb/constants.js
@@ -261,12 +261,12 @@ export const ENTITIESEXT = {
     {
       id: "origin",
       type: "string",
-      multival: true
+      ...getMult()
     },
     {
       id: "destination",
       type: "string",
-      multival: true
+      ...getMult()
     }
   ],
   FrequentFlyer: [


### PR DESCRIPTION
fixes #560 
fixed flight leg config.

To test, go to the rule builder and build a rule on the Flight Leg entity like:
`Flight Leg > origin = "AAA"` or
`Flight Leg > destination any_in "AAA, BBB"` etc

Save and re-open it and just verify that the values you select are still showing.