### PR TITLE
Fix/global modals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ yarn-error.log*
 eslintrc.json
 
 request.http
+.eslintcache

--- a/src/components/eventNotesModal/EventNotesModal.js
+++ b/src/components/eventNotesModal/EventNotesModal.js
@@ -55,7 +55,7 @@ const EventNotesModal = props => {
         size="md"
         aria-labelledby="contained-modal-title-vcenter"
         centered
-        className="max-500-width-container"
+        className="max-600-width-container"
       >
         <ModalHeader closeButton>
           <ModalTitle>

--- a/src/components/eventNotesModal/EventNotesModal.js
+++ b/src/components/eventNotesModal/EventNotesModal.js
@@ -65,7 +65,7 @@ const EventNotesModal = props => {
         <ModalBody>
           <Form
             title=""
-            submitText={<Xl8 xid="evn003">Save</Xl8>}
+            // submitText={<Xl8 xid="evn003">Save</Xl8>}
             submitService={paxEventNotesHistory.post}
             callback={handleClose}
             action="add"

--- a/src/components/modal/Modal.js
+++ b/src/components/modal/Modal.js
@@ -12,7 +12,6 @@ const Modal = props => {
         size={size}
         aria-labelledby="contained-modal-title-vcenter"
         centered
-        animation={false}
       >
         {props.children}
       </RBModal>

--- a/src/components/overlay/Overlay.scss
+++ b/src/components/overlay/Overlay.scss
@@ -3,3 +3,7 @@ $transparent: rgba(133, 130, 130, 0.6);
 .overlay-content {
   background-color: $transparent;
 }
+
+.bs-popover-top {
+  z-index: 12000;
+}

--- a/src/pages/admin/codeEditor/airport/AirportModal.js
+++ b/src/pages/admin/codeEditor/airport/AirportModal.js
@@ -43,8 +43,8 @@ const AirportModal = props => {
         </Button>,
         <Button
           type="button"
-          className="m-2 outline-dark-outline"
-          variant="outline-dark"
+          className="m-2"
+          variant="outline-danger"
           key="delete"
           onClick={() => props.actionCallback(ACTION.DELETE)}
         >

--- a/src/pages/admin/codeEditor/carrier/CarrierModal.js
+++ b/src/pages/admin/codeEditor/carrier/CarrierModal.js
@@ -42,8 +42,8 @@ const CarrierModal = props => {
         </Button>,
         <Button
           type="button"
-          className="m-2 outline-dark-outline"
-          variant="outline-dark"
+          className="m-2 "
+          variant="outline-danger"
           key="delete"
           onClick={() => props.actionCallback(ACTION.DELETE)}
         >

--- a/src/pages/admin/codeEditor/country/CountryModal.js
+++ b/src/pages/admin/codeEditor/country/CountryModal.js
@@ -42,8 +42,8 @@ const CountryModal = props => {
         </Button>,
         <Button
           type="button"
-          className="m-2 outline-dark-outline"
-          variant="outline-dark"
+          className="m-2 "
+          variant="outline-danger"
           key="delete"
           onClick={() => props.actionCallback(ACTION.DELETE)}
         >

--- a/src/pages/admin/codeEditor/creditcardtype/CreditCardTypeModal.js
+++ b/src/pages/admin/codeEditor/creditcardtype/CreditCardTypeModal.js
@@ -48,8 +48,8 @@ const CreditCardTypeModal = props => {
     customButtons.push(
       <Button
         type="button"
-        className="m-2 outline-dark-outline"
-        variant="outline-dark"
+        className="m-2"
+        variant="outline-danger"
         key="delete"
         onClick={() => props.actionCallback(ACTION.DELETE)}
       >

--- a/src/pages/admin/fileDownload/FileDownload.js
+++ b/src/pages/admin/fileDownload/FileDownload.js
@@ -5,7 +5,7 @@ import Title from "../../../components/title/Title";
 import Xl8 from "../../../components/xl8/Xl8";
 import Main from "../../../components/main/Main";
 import LabelledInput from "../../../components/labelledInput/LabelledInput";
-import { asArray, hasData, localeDate } from "../../../utils/utils";
+import { asArray, hasData, localeDate, formatBytes } from "../../../utils/utils";
 import "./fileDownload.css";
 
 const FileDownload = ({ name }) => {
@@ -79,7 +79,12 @@ const FileDownload = ({ name }) => {
       }
     },
     { Accessor: "fileName", Xl8: true, Header: ["fdl003", "File Name"] },
-    { Accessor: "size", Xl8: true, Header: ["fdl004", "Size"] },
+    {
+      Accessor: "size",
+      Xl8: true,
+      Header: ["fdl004", "Size"],
+      Cell: ({ row }) => formatBytes(row.original.size)
+    },
     {
       Accessor: "createDate",
       Xl8: true,

--- a/src/pages/paxDetail/PaxDetail.js
+++ b/src/pages/paxDetail/PaxDetail.js
@@ -229,7 +229,7 @@ const PaxDetail = props => {
           leftChild={tablist}
         ></Title>
         <Fab icon={<i className="fa fa-plus" />} variant="info">
-          <Action text={<Xl8 xid="not001">Notify</Xl8>}>
+          <Action text={<Xl8 xid="not001">Notify Users</Xl8>}>
             <Notification paxId={props.paxId} icon />
           </Action>
           <Action text={<Xl8 xid="rep001">Download Report</Xl8>}>

--- a/src/pages/paxDetail/addToWatchList/AddToWatchlist.js
+++ b/src/pages/paxDetail/addToWatchList/AddToWatchlist.js
@@ -134,6 +134,7 @@ const AddToWatchlist = props => {
                   This will add the following passenger and their applicable documents to
                   the watchlist:
                 </Xl8>
+                <br />
                 {passenger?.firstName} {passenger?.lastName}
               </Alert>
             </Form>

--- a/src/pages/paxDetail/addToWatchList/AddToWatchlist.js
+++ b/src/pages/paxDetail/addToWatchList/AddToWatchlist.js
@@ -104,7 +104,7 @@ const AddToWatchlist = props => {
       >
         <ModalHeader closeButton>
           <ModalTitle>
-            <Xl8 xid="atw002">Add Passenger/Document to Watchlist</Xl8>
+            <Xl8 xid="atw002">Add to Watchlist</Xl8>
           </ModalTitle>
         </ModalHeader>
 
@@ -112,7 +112,7 @@ const AddToWatchlist = props => {
           <Container fluid>
             <Form
               submitService={addWLItems.post}
-              submitText={<Xl8 xid="atw003">Add to Watchlist</Xl8>}
+              // submitText={<Xl8 xid="atw002">Add to Watchlist</Xl8>}
               title=""
               callback={handleClose}
               action="add"

--- a/src/pages/paxDetail/changeHitStatus/ChangeHitStatus.js
+++ b/src/pages/paxDetail/changeHitStatus/ChangeHitStatus.js
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
-import { SplitButton, Dropdown, Button } from "react-bootstrap";
+import { Button } from "react-bootstrap";
 import RoleAuthenticator from "../../../context/roleAuthenticator/RoleAuthenticator";
 import Xl8 from "../../../components/xl8/Xl8";
 import { ROLE } from "../../../utils/constants";
@@ -56,14 +56,17 @@ const ChangeHitStatus = props => {
           <Xl8 xid="chs004">Update Hit Status</Xl8>
         </ModalHeader>
         <ModalBody>
-          <Xl8 xid="chs005">Please click confirm to change the status to:</Xl8> {status}
+          <Xl8 xid="chs005">Please click confirm to change the status to:</Xl8>
+          <br />
+          <br />
+          {status}
         </ModalBody>
         <ModalFooter>
-          <Button variant="outline-success" onClick={handleConfirm}>
-            Confirm
-          </Button>
-          <Button variant="outline-danger" onClick={handleCancel}>
+          <Button variant="outline-dark" onClick={handleCancel}>
             Cancel
+          </Button>
+          <Button variant="primary" onClick={handleConfirm}>
+            Confirm
           </Button>
         </ModalFooter>
       </Modal>

--- a/src/pages/paxDetail/notification/Notification.js
+++ b/src/pages/paxDetail/notification/Notification.js
@@ -18,7 +18,7 @@ const Notification = props => {
   const cb = result => {};
   const [show, setShow] = useState(false);
   const [usersEmails, setUsersEmails] = useState(props.usersEmails);
-  const [showAlerText, setShowAlertText] = useState(false);
+  const [showAlertText, setShowAlertText] = useState(false);
 
   const handleClose = () => setShow(false);
   const handleShow = () => setShow(true);
@@ -76,7 +76,7 @@ const Notification = props => {
     </div>
   ) : (
     <div className="dropdown-item" onClick={handleShow}>
-      <Xl8 xid="not001">Notify</Xl8>
+      <Xl8 xid="not001">Notify Users</Xl8>
     </div>
   );
 
@@ -99,19 +99,18 @@ const Notification = props => {
         </ModalHeader>
         <ModalBody>
           <Container fluid>
-            {showAlerText && (
+            {showAlertText && (
               <ErrorText
                 message={
                   <Xl8 xid="not007">
-                    No user is selected, or external email address is provided! Please
-                    select users from the current user group or add external user.
+                    No user or external email address is provided! Please select users
+                    from the current user group or add external user.
                   </Xl8>
                 }
               />
             )}
             <Form
               title=""
-              submitText={<Xl8 xid="not003">Notify</Xl8>}
               submitService={notification.post}
               callback={handleClose}
               action="add"
@@ -124,19 +123,19 @@ const Notification = props => {
               <LabelledInput
                 name="to"
                 datafield="to"
-                labelText={<Xl8 xid="not004">Users in current group:</Xl8>}
+                labelText={<Xl8 xid="not004">Users in current group</Xl8>}
                 inputType="multiSelect"
                 inputVal={[]}
                 options={emialOptions}
                 callback={cb}
-                alt={<Xl8 xid="not004">Users in current group:</Xl8>}
+                alt="Users in current group"
               />
 
               <LabelledInput
                 inputType="text"
                 alt="nothing"
                 name="externalUsersEmail"
-                labelText={<Xl8 xid="not005">External user emails:</Xl8>}
+                labelText={<Xl8 xid="not005">External user emails</Xl8>}
                 placeholder="email@example.com"
                 datafield
                 inputVal=""

--- a/src/pages/paxDetail/uploadAttachment/AttachmentModal.js
+++ b/src/pages/paxDetail/uploadAttachment/AttachmentModal.js
@@ -167,7 +167,7 @@ const AttachmentModal = props => {
             title=""
             callback={postSubmit}
             action="add"
-            submitText={<Xl8 xid="attm005">Upload</Xl8>}
+            // submitText={<Xl8 xid="attm005">Upload</Xl8>}
             paramCallback={preSubmit}
             cancellable
           >

--- a/src/pages/paxDetail/uploadAttachment/AttachmentModal.js
+++ b/src/pages/paxDetail/uploadAttachment/AttachmentModal.js
@@ -68,8 +68,10 @@ const AttachmentModal = props => {
   };
 
   const isCountValid = files => {
-    setAlertContent(<Xl8 xid="attm007">Too many files were selected</Xl8>);
-    return files.length <= fileUploadLimit;
+    const result = files.length <= fileUploadLimit;
+
+    if (!result) setAlertContent(<Xl8 xid="attm007">Too many files were selected</Xl8>);
+    return result;
   };
 
   const isSizeValid = files => {

--- a/src/pages/paxDetail/uploadAttachment/UploadAttachment.js
+++ b/src/pages/paxDetail/uploadAttachment/UploadAttachment.js
@@ -18,10 +18,7 @@ const UploadAttachment = props => {
   const [showModal, setShowModal] = useState(false);
   const paxId = props.paxId;
 
-  const cb = (status, resp) => { //SLATE FOR REMOVAL -- DOES NOTHING AS PAX DETAIL CONTROLS CALLBACK FOR ATTACHMENT MODAL NOW
-    if (status !== ACTION.CLOSE && status !== ACTION.CANCEL)
-      setRefreshDataKey(refreshDataKey + 1);
-  };
+  const cb = (status, resp) => {};
 
   const deleteAttachment = row => {
     attachment.del(row.id).then(resp => {
@@ -48,7 +45,7 @@ const UploadAttachment = props => {
       setData(resp);
       setTableKey(tableKey + 1);
     });
-  }, [props.attachmentRefreshKey]);
+  }, [refreshDataKey, props.attachmentRefreshKey]);
 
   const headers = [
     {
@@ -120,7 +117,6 @@ const UploadAttachment = props => {
 
   return (
     <div className="one-column-grid-container">
-      {/* <Title title={<Xl8 xid="att009">Uploaded Attachments</Xl8>} rightChild={button} /> */}
       <Table data={data} id="attachments" header={headers} key={tableKey} callback={cb} />
     </div>
   );

--- a/src/pages/paxDetail/uploadAttachment/UploadAttachment.scss
+++ b/src/pages/paxDetail/uploadAttachment/UploadAttachment.scss
@@ -1,12 +1,4 @@
 .files input {
-  // outline: 2px dashed #92b0b3;
-  // outline-offset: -10px;
-  // -webkit-transition: outline-offset 0.15s ease-in-out, background-color 0.15s linear;
-  // transition: outline-offset 0.15s ease-in-out, background-color 0.15s linear;
-  // padding: 120px 0px 85px 35%;
-  // text-align: center !important;
-  // margin: 0;
-  // width: 100% !important;
   width: 100% !important;
   opacity: 0;
   white-space: normal;
@@ -20,6 +12,7 @@
   transition: outline-offset 0.15s ease-in-out, background-color 0.15s linear;
   border: 1px solid #92b0b3;
 }
+
 .files {
   position: relative;
   border: 2px dashed #009e92;
@@ -81,4 +74,12 @@
   padding-left: 15px;
   margin-right: auto;
   margin-left: auto;
+}
+
+.attachment-files-title {
+  display: flex;
+  .error-text {
+    margin-left: 20px;
+    align-self: center;
+  }
 }

--- a/src/pages/paxDetail/uploadAttachment/UploadAttachment.scss
+++ b/src/pages/paxDetail/uploadAttachment/UploadAttachment.scss
@@ -3,14 +3,6 @@
   opacity: 0;
   white-space: normal;
   height: 150px;
-  background-color: yellow;
-}
-.files input:focus {
-  outline: 2px dashed #92b0b3;
-  outline-offset: -10px;
-  -webkit-transition: outline-offset 0.15s ease-in-out, background-color 0.15s linear;
-  transition: outline-offset 0.15s ease-in-out, background-color 0.15s linear;
-  border: 1px solid #92b0b3;
 }
 
 .files {
@@ -41,7 +33,6 @@
 }
 
 .upload input[type="file"] {
-  text-indent: -999em;
   outline: none;
   width: 100%;
   height: 100%;

--- a/src/pages/paxDetail/uploadAttachment/UploadAttachment.scss
+++ b/src/pages/paxDetail/uploadAttachment/UploadAttachment.scss
@@ -1,12 +1,17 @@
 .files input {
-  outline: 2px dashed #92b0b3;
-  outline-offset: -10px;
-  -webkit-transition: outline-offset 0.15s ease-in-out, background-color 0.15s linear;
-  transition: outline-offset 0.15s ease-in-out, background-color 0.15s linear;
-  padding: 120px 0px 85px 35%;
-  text-align: center !important;
-  margin: 0;
+  // outline: 2px dashed #92b0b3;
+  // outline-offset: -10px;
+  // -webkit-transition: outline-offset 0.15s ease-in-out, background-color 0.15s linear;
+  // transition: outline-offset 0.15s ease-in-out, background-color 0.15s linear;
+  // padding: 120px 0px 85px 35%;
+  // text-align: center !important;
+  // margin: 0;
+  // width: 100% !important;
   width: 100% !important;
+  opacity: 0;
+  white-space: normal;
+  height: 150px;
+  background-color: yellow;
 }
 .files input:focus {
   outline: 2px dashed #92b0b3;
@@ -17,40 +22,29 @@
 }
 .files {
   position: relative;
+  border: 2px dashed #009e92;
+  border-radius: 0.25rem;
 }
-.files:after {
-  pointer-events: none;
+
+.files::before {
+  content: "\f0ab";
+  font-family: FontAwesome;
+  font-style: normal;
+  font-weight: normal;
+  text-decoration: inherit;
+  font-size: 120px;
+  color: #e3f7f6;
+  top: calc(50% - 60px);
+  left: calc(50% - 60px);
+  line-height: 1;
   position: absolute;
-  top: 60px;
-  left: 0;
-  width: 50px;
-  right: 0;
-  height: 56px;
-  content: "";
-  background-image: url(https://image.flaticon.com/icons/png/128/109/109612.png);
-  display: block;
-  margin: 0 auto;
-  background-size: 100%;
-  background-repeat: no-repeat;
+}
+
+.files:hover {
+  background-color: #e3f7f6;
 }
 .color input {
   background-color: #f1f1f1;
-}
-.files:before {
-  position: absolute;
-  bottom: 10px;
-  left: 0;
-  pointer-events: none;
-  width: 100%;
-  right: 0;
-  height: 57px;
-  content: " or drag it here. ";
-  display: block;
-  margin: 0 auto;
-  color: #2ea591;
-  font-weight: 600;
-  text-transform: capitalize;
-  text-align: center;
 }
 
 .upload input[type="file"] {
@@ -59,4 +53,32 @@
   width: 100%;
   height: 100%;
   position: absolute;
+}
+
+.attachment-data {
+  position: absolute;
+  top: 45px;
+  left: 30px;
+  width: calc(100% - 60px);
+}
+
+.attachment-data > div {
+  white-space: nowrap !important;
+  overflow: hidden;
+}
+
+.attachment-size {
+  margin-left: 10px;
+}
+
+.attachment-form-container {
+  margin-top: 20px;
+}
+
+.attachment-form-container > div {
+  width: 100%;
+  padding-right: 15px;
+  padding-left: 15px;
+  margin-right: auto;
+  margin-left: auto;
 }

--- a/src/pages/tools/queryrules/QRModal.js
+++ b/src/pages/tools/queryrules/QRModal.js
@@ -1,8 +1,14 @@
 import React, { useState, useEffect, useMemo, useContext } from "react";
 import RAQB from "../../../components/raqb/RAQB";
-import { Button, Container, Row } from "react-bootstrap";
+import { Button, Row } from "react-bootstrap";
 import LabelledInput from "../../../components/labelledInput/LabelledInput";
 import Xl8 from "../../../components/xl8/Xl8";
+import Modal, {
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle
+} from "../../../components/modal/Modal";
 import { navigate } from "@reach/router";
 import { hasData, asArray, localeDateOnly } from "../../../utils/utils";
 import { QR, ACTION, CTX, ROLE } from "../../../utils/constants";
@@ -18,12 +24,6 @@ import {
 
 import { numProps, txtProps, dateProps } from "../../../components/raqb/constants";
 import "./QueryRules.css";
-import Modal, {
-  ModalBody,
-  ModalFooter,
-  ModalHeader,
-  ModalTitle
-} from "../../../components/modal/Modal";
 
 const QRModal = props => {
   const id = props.id;
@@ -785,7 +785,7 @@ const QRModal = props => {
             )}
           </div>
         </ModalBody>
-        <ModalFooter>
+        <ModalFooter className="qbrb-modal-footer">
           <Button
             type="button"
             key="close"
@@ -793,7 +793,16 @@ const QRModal = props => {
             variant="outline-dark"
             onClick={onClose}
           >
-            <Xl8 xid="qrm007">Close</Xl8>
+            <Xl8 xid="qrm007">Cancel</Xl8>
+          </Button>
+          <Button
+            key="save"
+            type="button"
+            className="m-2 btn"
+            variant="primary"
+            onClick={onSave}
+          >
+            <Xl8 xid="qrm009">Submit</Xl8>
           </Button>
           <Button
             type="button"
@@ -803,15 +812,6 @@ const QRModal = props => {
             onClick={onClear}
           >
             <Xl8 xid="QRM008">Clear</Xl8>
-          </Button>
-          <Button
-            key="save"
-            type="button"
-            className="m-2 btn"
-            variant="primary"
-            onClick={onSave}
-          >
-            <Xl8 xid="qrm009">Save</Xl8>
           </Button>
 
           <RoleAuthenticator roles={[ROLE.ADMIN, ROLE.QRYMGR]} alt={<></>}>
@@ -829,8 +829,8 @@ const QRModal = props => {
             <Button
               key="delete"
               type="button"
-              className="m-2 outline-dark-outline"
-              variant="outline-dark"
+              className="m-2"
+              variant="outline-danger"
               onClick={onDelete}
             >
               <Xl8 xid="qrm011">Delete</Xl8>

--- a/src/pages/tools/queryrules/QueryRules.css
+++ b/src/pages/tools/queryrules/QueryRules.css
@@ -329,3 +329,7 @@ pre {
   transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
   max-width: 160px;
 }
+
+.qbrb-modal-footer {
+  justify-content: center !important;
+}

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -359,3 +359,16 @@ export const lpad5 = val => {
     .toString()
     .padStart(5, "0");
 };
+
+// copied direct from stacko, but tested.
+export const formatBytes = (bytes, decimals = 2) => {
+  if (bytes === 0) return "0 Bytes";
+
+  const k = 1024;
+  const dm = decimals < 0 ? 0 : decimals;
+  const sizes = ["Bytes", "KB", "MB", "GB"];
+
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + " " + sizes[i];
+};


### PR DESCRIPTION
fixes #491 , #550 

- restored bootstrap animation to the modals so they glide in
- standardized button layout and styles
     Delete is red outlined, rightmost button
     Cancel is black outlined, leftmost
     Submit is blue, next to cancel, always says "Submit" now
     Other buttons are black outlined and between Submit and Delete
- Fixed modal placement and widths where text was overrunning/colliding
- Attachments modal:
    - Updated layout to align file names
    - Added missing translation tags
    - Added missing validation messages for file size and count
    - Fixed size validation not firing for large files
    - Changed the max file size from 15KB to 5MB
    - Fixed displayed file list not refreshing when new files are added
    - Fixed attachments table not refreshing on delete
    - Converted filesize values to storage units (attachments and on file download)
