### PR TITLE
fix routing, wl permissions, reset page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,12 +1,10 @@
-import React, { Suspense } from "react";
+import React, { Suspense, useState, useRef } from "react";
 import { Router, Redirect, navigate } from "@reach/router";
 import IdleTimer from "react-idle-timer";
 import loadable from "@loadable/component";
 
 import Xl8 from "./components/xl8/Xl8";
 
-import Authenticator from "./context/authenticator/Authenticator";
-import RoleAuthenticator from "./context/roleAuthenticator/RoleAuthenticator";
 import UserProvider from "./context/user/UserContext";
 import LiveEditProvider from "./context/translation/LiveEditContext";
 import LookupProvider from "./context/data/LookupContext";
@@ -24,6 +22,12 @@ import { FULLPATH_TO } from "./utils/constants";
 import "./App.scss";
 import "font-awesome/css/font-awesome.min.css";
 
+const Authenticator = loadable(() =>
+  import(/* webpackChunkName: "authed" */ "./context/authenticator/Authenticator")
+);
+const RoleAuthenticator = loadable(() =>
+  import(/* webpackChunkName: "authed" */ "./context/roleAuthenticator/RoleAuthenticator")
+);
 const Flights = loadable(() =>
   import(/* webpackChunkName: "authed" */ "./pages/flights/Flights")
 );
@@ -31,9 +35,9 @@ const PriorityVetting = loadable(() =>
   import(/* webpackChunkName: "authed" */ "./pages/vetting/Vetting")
 );
 const Home = loadable(() => import(/* webpackChunkName: "authed" */ "./pages/home/Home"));
-const Dashboard = loadable(() =>
-  import(/* webpackChunkName: "authed" */ "./pages/dashboard/Dashboard")
-);
+// const Dashboard = loadable(() =>
+//   import(/* webpackChunkName: "authed" */ "./pages/dashboard/Dashboard")
+// );
 const PaxDetail = loadable(() =>
   import(/* webpackChunkName: "authed" */ "./pages/paxDetail/PaxDetail")
 );
@@ -148,60 +152,58 @@ const LanguageEditor = loadable(() =>
   import(/* webpackChunkName: "admin" */ "./pages/lang/LanguageEditor")
 );
 
-export default class App extends React.Component {
-  constructor(props) {
-    super(props);
-    this.idleTimer = null;
-    this.onAction = this._onAction.bind(this);
-    this.onActive = this._onActive.bind(this);
-    this.onIdle = this._onIdle.bind(this);
-    this.state = {
-      showModal: false,
-      redirect: false
-    };
-  }
+const App = props => {
+  const [showModal, setShowModal] = useState(false);
+  const idleTimer = useRef(null);
 
-  _onAction(e) {
+  const onAction = e => {
     // console.log('user did something', e)
-  }
+  };
 
-  _onActive(e) {
+  const onActive = e => {
     // console.log('user is active', e)
-    // console.log('time remaining', this.idleTimer.getRemainingTime())
-  }
+    // console.log('time remaining', idleTimer.getRemainingTime())
+  };
 
-  _onIdle(e) {
+  const onIdle = e => {
     console.log("user is idle", e);
-    console.log("last active", this.idleTimer.getLastActiveTime());
+    console.log("last active", idleTimer.getLastActiveTime());
 
     // Logout and redirect to login page
     // this.setState({ redirect: true });
     navigate(FULLPATH_TO.LOGIN);
-  }
+  };
 
-  toggleModal() {
+  const toggleModal = () => {
     // this.setState({ showModal: !this.state.showModal });
-  }
+  };
 
-  render() {
-    const UNAUTHED = <PageUnauthorized path="pageUnauthorized"></PageUnauthorized>;
+  const UNAUTHED = <PageUnauthorized path="pageUnauthorized"></PageUnauthorized>;
+  const NF404 = <Page404 path="page404"></Page404>;
 
-    return (
-      <React.StrictMode>
+  return (
+    <React.StrictMode>
+      <>
         <UserProvider>
           <LookupProvider>
             <LiveEditProvider>
               <Suspense fallback="loading">
                 <Router>
-                  {/* TEST ME */}
-                  {/* <Redirect from="/" to="/gtas/login" noThrow /> */}
+                  {NF404}
+                  <Redirect from="/" to={FULLPATH_TO.LOGIN} noThrow />
+                  <ResetPassword
+                    path={`${FULLPATH_TO.RESETPWD}/:username/:resetToken`}
+                  ></ResetPassword>
+                  <ForgotPassword path={FULLPATH_TO.FORGOTPWD}></ForgotPassword>
                   <Login path={FULLPATH_TO.LOGIN}></Login>
                   <SignUp path={FULLPATH_TO.SIGNUP}></SignUp>
-                  <ResetPassword path="/gtas/reset-password/:username/:resetToken"></ResetPassword>
-                  <ForgotPassword path={FULLPATH_TO.FORGOTPWD}></ForgotPassword>
                 </Router>
               </Suspense>
-              {/* {this.state.showModal ? (
+            </LiveEditProvider>
+          </LookupProvider>
+        </UserProvider>
+
+        {/* {this.state.showModal ? (
                 <GModal>
                   <div>
                     <h1>You have been inactive for {this.idleTimer.getElapsedTime()}</h1>
@@ -209,22 +211,22 @@ export default class App extends React.Component {
                   </div>
                 </GModal>
               ) : null} */}
+        <UserProvider>
+          <LookupProvider>
+            <LiveEditProvider>
               <div className="App">
                 <IdleTimer
-                  ref={ref => {
-                    this.idleTimer = ref;
-                  }}
+                  ref={idleTimer}
                   element={document}
-                  onActive={this.onActive}
-                  onIdle={this.onIdle}
-                  onAction={this.onAction}
+                  onActive={onActive}
+                  onIdle={onIdle}
+                  onAction={onAction}
                   debounce={250}
                   timeout={TIME.MINUTES_25}
                 />
                 <Suspense fallback="loading">
-                  <Authenticator>
-                    <Router>
-                      {UNAUTHED}
+                  <Router>
+                    <Authenticator path="/gtas">
                       <RoleAuthenticator
                         path="/"
                         roles={[
@@ -237,10 +239,9 @@ export default class App extends React.Component {
                           ROLE.FLIGHTVWR
                         ]}
                       >
-                        <Redirect from="/" to={FULLPATH_TO.LOGIN} noThrow />
-                        <Home path="/gtas">
-                          <Page404 default></Page404>
-                          <Redirect from="/gtas" to={FULLPATH_TO.FLIGHTS} noThrow />
+                        {UNAUTHED}
+                        <Home path="/">
+                          <Redirect from="/" to={FULLPATH_TO.FLIGHTS} noThrow />
                           <RoleAuthenticator
                             path="flights"
                             roles={[ROLE.ADMIN, ROLE.FLIGHTVWR]}
@@ -278,12 +279,16 @@ export default class App extends React.Component {
                             <Rules path="rules/:mode"></Rules>
                             <Queries path="queries"></Queries>
                             <QRDetails path="qrdetails"></QRDetails>
-                            <Watchlist path="watchlist"></Watchlist>
-                            <Watchlist path="watchlist/:mode"></Watchlist>
+                            <RoleAuthenticator
+                              path="watchlist"
+                              roles={[ROLE.ADMIN, ROLE.WLMGR]}
+                            >
+                              <Watchlist path="/"></Watchlist>
+                              <Watchlist path="/:mode"></Watchlist>
+                            </RoleAuthenticator>
                             <About path="about"></About>
                           </Tools>
                           <Search path="search/:searchParam"></Search>
-                          <SeatChart path="seat-chart/:flightId/:paxId/:currentPaxSeat"></SeatChart>
                           <RoleAuthenticator
                             path="seat-chart/:flightId/:paxId/:currentPaxSeat"
                             roles={[ROLE.ADMIN, ROLE.PAXVWR]}
@@ -293,12 +298,8 @@ export default class App extends React.Component {
                           <RoleAuthenticator path="langEditor" roles={[ROLE.ADMIN]}>
                             <LanguageEditor path="/"></LanguageEditor>
                           </RoleAuthenticator>
-                          <RoleAuthenticator
-                            path="admin"
-                            alt={UNAUTHED}
-                            roles={[ROLE.ADMIN]}
-                          >
-                            <Admin path="/">
+                          <RoleAuthenticator path="admin" roles={[ROLE.ADMIN]}>
+                            <Admin path="/" default>
                               <ManageUser
                                 name={<Xl8 xid="app009">Manage Users</Xl8>}
                                 path="manageusers"
@@ -348,11 +349,11 @@ export default class App extends React.Component {
                                 desc={<Xl8 xid="app021">View or edit system codes</Xl8>}
                                 icon="fa-list-ul"
                                 path="codeeditor"
-                                startTab="country"
                               >
                                 <Country
                                   name={<Xl8 xid="app022">Country</Xl8>}
                                   path="country"
+                                  default
                                 ></Country>
                                 <Airport
                                   name={<Xl8 xid="app023">Airport</Xl8>}
@@ -410,14 +411,16 @@ export default class App extends React.Component {
                           {UNAUTHED}
                         </Home>
                       </RoleAuthenticator>
-                    </Router>
-                  </Authenticator>
+                    </Authenticator>
+                  </Router>
                 </Suspense>
               </div>
             </LiveEditProvider>
           </LookupProvider>
         </UserProvider>
-      </React.StrictMode>
-    );
-  }
-}
+      </>
+    </React.StrictMode>
+  );
+};
+
+export default App;

--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -105,7 +105,7 @@ const Header = () => {
         <Navbar.Brand className="header-navbar-brand">
           <RoleAuthenticator roles={[ROLE.ADMIN, ROLE.FLIGHTVWR]} alt={<></>}>
             <Link to="flights" onClick={() => clickTab(htab.FLIGHT)}>
-              <img src={wcoLogo} />
+              <img src={wcoLogo} alt="WCO logo" />
             </Link>
           </RoleAuthenticator>
         </Navbar.Brand>

--- a/src/components/seatChart/SeatChart.js
+++ b/src/components/seatChart/SeatChart.js
@@ -13,7 +13,7 @@ import Xl8 from "../xl8/Xl8";
 import "./SeatChart.scss";
 
 const SeatChart = ({ location }) => {
-  const { flightId, currentPaxSeat } = useParams();
+  const { flightId, paxId, currentPaxSeat } = useParams();
   const [reservedSeatsInfo, setReservedSeatsInfo] = useState({});
   const [columnWithReservedSeat, setColumnWithReservedSeat] = useState([]);
   const [rowsWithReservedSeat, setRowsWithReservedSeat] = useState([]);
@@ -31,7 +31,7 @@ const SeatChart = ({ location }) => {
           selected={currentPaxSeat === seatNumber}
           key={seatNumber}
           className={
-            selectedSeatInfo.coTravellers.includes(seatNumber) ? "co-traveler" : ""
+            selectedSeatInfo.coTravellers?.includes(seatNumber) ? "co-traveler" : ""
           }
         />
       );
@@ -66,6 +66,7 @@ const SeatChart = ({ location }) => {
       ? "left-of-middle-rows"
       : "";
   };
+
   useEffect(() => {
     seats.get(flightId).then(res => {
       processData(res);
@@ -78,14 +79,17 @@ const SeatChart = ({ location }) => {
   }, [reservedSeatsInfo]);
 
   const flightInfoData = [
-    { label: <Xl8 xid="seat004">Flight Number</Xl8>, value: location.state.flightNumber },
+    {
+      label: <Xl8 xid="seat004">Flight Number</Xl8>,
+      value: location.state?.flightNumber
+    },
     {
       label: <Xl8 xid="seat005">Arrival</Xl8>,
-      value: localeDate(location.state.arrival)
+      value: localeDate(location.state?.arrival)
     },
     {
       label: <Xl8 xid="seat006">Departure</Xl8>,
-      value: localeDate(location.state.departure)
+      value: localeDate(location.state?.departure)
     }
   ];
 
@@ -104,14 +108,10 @@ const SeatChart = ({ location }) => {
       value: selectedSeatInfo.number
     }
   ];
-  const linkToFlightPax = (
-    <Link to={`/gtas/flightpax/${location.state.flightId}`}>Flightpax</Link>
-  );
+  const linkToFlightPax = <Link to={`/gtas/flightpax/${flightId}`}>Flightpax</Link>;
 
   const linkToPaxdetails = (
-    <Link to={`/gtas/paxDetail/${selectedSeatInfo.flightId}/${selectedSeatInfo.paxId}`}>
-      Show passenger details
-    </Link>
+    <Link to={`/gtas/paxDetail/${flightId}/${paxId}`}>Show passenger details</Link>
   );
 
   return (

--- a/src/components/seatChart/seat/Seat.js
+++ b/src/components/seatChart/seat/Seat.js
@@ -15,8 +15,7 @@ const Seat = props => {
     <>
       <Button
         variant="light"
-        size="sm"
-        className={`seat ${selectedSeatClass} ${hasHitClass} ${props.className} `}
+        className={`seat ${selectedSeatClass} ${hasHitClass} ${props.className}`}
         disabled={!reserved}
         onClick={() => setShowModal(true)}
       >

--- a/src/components/seatChart/seat/Seat.scss
+++ b/src/components/seatChart/seat/Seat.scss
@@ -1,13 +1,13 @@
 .seat {
   border-color: rgb(245, 241, 241) !important;
-  background-color: rgb(6, 146, 81);
+  background-color: rgb(6, 146, 81) !important;
   color: rgb(216, 211, 211);
-  font-size: 0.75rem;
-  font-weight: 700;
+  font-size: 0.75rem !important;
+  font-weight: 700 !important;
   border-radius: 0.3rem;
   max-width: 30px;
   min-width: 30px;
-  padding: 0.15px 0.15px;
+  padding: 0.15px 0.15px !important;
   transform: rotate(-90deg);
   margin-bottom: 2px;
 }

--- a/src/context/roleAuthenticator/RoleAuthenticator.js
+++ b/src/context/roleAuthenticator/RoleAuthenticator.js
@@ -8,7 +8,6 @@ const UNAUTHED = <PageUnauthorized path="pageUnauthorized"></PageUnauthorized>;
 const RoleAuthenticator = props => {
   const alt = props.alt ?? UNAUTHED;
   const { getUserState } = useContext(UserContext);
-
   let hasRole = false;
 
   const userRoles = getUserState().userRoles.map(item => titleCase(item));

--- a/src/pages/admin/codeEditor/CodeEditor.js
+++ b/src/pages/admin/codeEditor/CodeEditor.js
@@ -5,13 +5,11 @@ import Xl8 from "../../../components/xl8/Xl8";
 import { Tabs, Tab } from "react-bootstrap";
 import { navigate } from "@reach/router";
 import { getEndpoint } from "../../../utils/utils";
-
 import "./CodeEditor.css";
 
 const CodeEditor = props => {
   const endpoint = getEndpoint(props.location?.pathname);
   const startTab = endpoint === "codeeditor" ? "country" : endpoint;
-  const tabcontent = props.children.props.children;
   const [tab, setTab] = useState(startTab);
 
   function tabHandler(ev) {
@@ -28,7 +26,7 @@ const CodeEditor = props => {
   }, [tab]);
 
   const headerTabs = (
-    <Tabs defaultActiveKey="country" id="codeTabs" className="gtas-tabs">
+    <Tabs defaultActiveKey={startTab} id="codeTabs" className="gtas-tabs" key={startTab}>
       <Tab
         eventKey="country"
         title={
@@ -63,11 +61,6 @@ const CodeEditor = props => {
       ></Tab>
     </Tabs>
   );
-
-  let tabMap = {};
-  tabcontent.forEach(function(tab) {
-    tabMap[tab.props.path] = tab.props.name;
-  });
 
   return (
     <Main className="full bg-white">

--- a/src/pages/admin/errorLog/ErrorLog.js
+++ b/src/pages/admin/errorLog/ErrorLog.js
@@ -1,6 +1,6 @@
-import React, {useEffect, useState} from "react";
+import React, { useEffect, useState } from "react";
 import Table from "../../../components/table/Table";
-import {errorlog} from "../../../services/serviceWrapper";
+import { errorlog } from "../../../services/serviceWrapper";
 import Title from "../../../components/title/Title";
 import Xl8 from "../../../components/xl8/Xl8";
 import Main from "../../../components/main/Main";
@@ -8,7 +8,7 @@ import SidenavContainer from "../../../components/sidenavContainer/SidenavContai
 import { Col } from "react-bootstrap";
 import LabelledInput from "../../../components/labelledInput/LabelledInput";
 import FilterForm from "../../../components/filterForm2/FilterForm";
-import {asArray, localeDate} from "../../../utils/utils";
+import { asArray, localeDate } from "../../../utils/utils";
 
 const ErrorLog = ({ name }) => {
   const cb = function(result) {};
@@ -19,7 +19,7 @@ const ErrorLog = ({ name }) => {
   const selectAllCodes = "Select All Codes";
   let startDate = new Date();
   let endDate = new Date();
-  endDate.setDate(endDate.getDate() + 1);
+  endDate.setDate(endDate.getDate());
   startDate.setDate(startDate.getDate() - 1);
   const initialParamState = () => {
     return { startDate: startDate, endDate: endDate };
@@ -29,22 +29,22 @@ const ErrorLog = ({ name }) => {
     {
       Accessor: "errorId",
       Xl8: true,
-      Header: ["el005", "Error Id"]
+      Header: ["el005", "ID"]
     },
     {
       Accessor: "errorCode",
       Xl8: true,
-      Header: ["el006", "Error Code"]
+      Header: ["el006", "Code"]
     },
     {
       Accessor: "errorDescription",
       Xl8: true,
-      Header: ["el007", "Error Description"]
+      Header: ["el007", "Description"]
     },
     {
       Accessor: "timestamp",
       Xl8: true,
-      Header: ["el008", "Error Timestamp"],
+      Header: ["el008", "Timestamp"],
       Cell: ({ row }) => localeDate(row.original.timestamp)
     }
   ];
@@ -66,16 +66,18 @@ const ErrorLog = ({ name }) => {
   };
 
   useEffect(() => {
-    errorlog.get.codes().then(res =>{
-      let codes = [{label:selectAllCodes, value:selectAllCodes}]; //Always top dummy value
-      codes = codes.concat(asArray(res).map(code => {
-        return {
-          label: code,
-          value: code,
-        };
-      }));
+    errorlog.get.codes().then(res => {
+      let codes = [{ label: selectAllCodes, value: selectAllCodes }]; //Always top dummy value
+      codes = codes.concat(
+        asArray(res).map(code => {
+          return {
+            label: code,
+            value: code
+          };
+        })
+      );
       setErrorCodes(codes);
-      setFilterKey(filterKey+1);
+      setFilterKey(filterKey + 1);
     });
   }, []);
 
@@ -96,15 +98,15 @@ const ErrorLog = ({ name }) => {
             key={filterKey}
           >
             <LabelledInput
-                labelText={<Xl8 xid="el001">Error Codes</Xl8>}
-                datafield="errorCode"
-                inputType="select"
-                name="errorCode"
-                inputVal={selectAllCodes}
-                options={errorCodes}
-                required={true}
-                alt="nothing"
-                callback={cb}
+              labelText={<Xl8 xid="el001">Error Codes</Xl8>}
+              datafield="errorCode"
+              inputType="select"
+              name="errorCode"
+              inputVal={selectAllCodes}
+              options={errorCodes}
+              required={true}
+              alt="nothing"
+              callback={cb}
             />
             <LabelledInput
               datafield

--- a/src/pages/login/ResetPassword.js
+++ b/src/pages/login/ResetPassword.js
@@ -2,8 +2,9 @@ import React, { useState, useEffect } from "react";
 import Form from "../../components/form/Form";
 import LabelledInput from "../../components/labelledInput/LabelledInput";
 import { resetPassword } from "../../services/serviceWrapper";
-import { Container, Alert } from "react-bootstrap";
+import { Container, Alert, Col } from "react-bootstrap";
 import Title from "../../components/title/Title";
+import Main from "../../components/main/Main";
 import Xl8 from "../../components/xl8/Xl8";
 import { hasData } from "../../utils/utils";
 import { useParams, Link } from "@reach/router";
@@ -42,68 +43,76 @@ const ResetPassword = props => {
   }, []);
 
   return (
-    <Container className="password-reset-container" fluid>
-      <Title title={<Xl8 xid="passres001">Reset Password</Xl8>} uri={props.uri} />
-      {validToken ? (
-        <>
-          {displayErrorMessage && (
-            <Alert variant="danger">
-              {errorMessage}
-              <br />
-              <Link to={FULLPATH_TO.FORGOTPWD}>
-                <Xl8 xid="passres002">Send another password reset link?</Xl8>
-              </Link>
-            </Alert>
-          )}
-          {displaySuccessMessage ? (
-            <Alert variant="success">
-              <Xl8 xid="passres003">Your password has been reset! Click </Xl8>
-              <Link to={FULLPATH_TO.LOGIN}>
-                <Xl8 xid="passres004">here</Xl8>
-              </Link>
-              <Xl8 xid="passres005">to login to GTAS</Xl8>
-            </Alert>
+    <Main className="unauthed bg-image">
+      <Container
+        className="login d-flex align-items-center py-5 justify-content-around"
+        fluid
+      >
+        <Col className="unauthed-form">
+          {validToken ? (
+            <>
+              {displayErrorMessage && (
+                <Alert variant="danger">
+                  {errorMessage}
+                  <br />
+                  <Link to={FULLPATH_TO.FORGOTPWD}>
+                    <Xl8 xid="passres002">Send another password reset link?</Xl8>
+                  </Link>
+                </Alert>
+              )}
+              {displaySuccessMessage ? (
+                <Alert variant="success">
+                  <Xl8 xid="passres003">Your password has been reset! Click </Xl8>
+                  <Link to={FULLPATH_TO.LOGIN}>
+                    <Xl8 xid="passres004">here</Xl8>
+                  </Link>
+                  <Xl8 xid="passres005">to login to GTAS</Xl8>
+                </Alert>
+              ) : (
+                <Form
+                  submitService={resetPassword.post}
+                  title=""
+                  callback={passwordResetCallback}
+                  action="add"
+                  redirectTo={FULLPATH_TO.LOGIN}
+                  paramCallback={preSubmitCallback}
+                  cancellable
+                >
+                  <LabelledInput
+                    datafield
+                    labelText={<Xl8 xid="pass004">New password</Xl8>}
+                    inputType="password"
+                    name="password"
+                    required={true}
+                    inputVal=""
+                    alt="nothing"
+                    callback={cb}
+                  />
+                  <LabelledInput
+                    datafield
+                    labelText={<Xl8 xid="pass005">Confirm new password</Xl8>}
+                    inputType="password"
+                    name="passwordConfirm"
+                    required={true}
+                    inputVal=""
+                    alt="nothing"
+                    callback={cb}
+                  />
+                </Form>
+              )}
+            </>
           ) : (
-            <Form
-              submitService={resetPassword.post}
-              title=""
-              callback={passwordResetCallback}
-              action="add"
-              redirectTo={FULLPATH_TO.LOGIN}
-              paramCallback={preSubmitCallback}
-              cancellable
-            >
-              <LabelledInput
-                datafield
-                labelText={<Xl8 xid="pass004">New password</Xl8>}
-                inputType="password"
-                name="password"
-                required={true}
-                inputVal=""
-                alt="nothing"
-                callback={cb}
-                spacebetween
-              />
-              <LabelledInput
-                datafield
-                labelText={<Xl8 xid="pass005">Confirm new password</Xl8>}
-                inputType="password"
-                name="passwordConfirm"
-                required={true}
-                inputVal=""
-                alt="nothing"
-                callback={cb}
-                spacebetween
-              />
-            </Form>
+            <>
+              <Alert variant="danger">
+                <Xl8 xid="passres006">Invalid token provided. Please try again!</Xl8>
+              </Alert>
+              <br />
+              <Link to={FULLPATH_TO.LOGIN}>Back to Login</Link>
+            </>
           )}
-        </>
-      ) : (
-        <Alert variant="danger">
-          <Xl8 xid="passres006">Invalid token provided. Please try again!</Xl8>
-        </Alert>
-      )}
-    </Container>
+        </Col>
+      </Container>
+    </Main>
   );
 };
 

--- a/src/pages/login/SignUp.js
+++ b/src/pages/login/SignUp.js
@@ -4,7 +4,6 @@ import Form from "../../components/form/Form";
 import Main from "../../components/main/Main";
 import { signup, physicalLocations } from "../../services/serviceWrapper";
 import LabelledInput from "../../components/labelledInput/LabelledInput";
-import Title from "../../components/title/Title";
 import Xl8 from "../../components/xl8/Xl8";
 import { asArray, hasData } from "../../utils/utils";
 import { Link } from "@reach/router";

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -61,10 +61,11 @@ export const CTX = {
 // router paths to the most commonly referenced pages
 // may also need a util to build partials
 export const FULLPATH_TO = {
-  LOGIN: "/gtas/login",
+  LOGIN: "/login",
   FLIGHTS: "/gtas/flights",
-  FORGOTPWD: "/gtas/forgot-password",
-  SIGNUP: "/gtas/signup"
+  FORGOTPWD: "/forgot-password",
+  RESETPWD: "/reset-password",
+  SIGNUP: "/signup"
 };
 
 export const TIME = {


### PR DESCRIPTION
Fixes #563, #561, #211 

- Fixed issue with router paths
- Added role validation on the watchlist page (links were hidden but the page was still accessible)
- Removed erroneous route granting full access to the seats page
- Fixed error and broken css when navving directly to seat-chart without going through paxdetail first
- Fixed broken rerouting in Code Editor that prevented backward navigation with the browser back button.
