### PR TITLE
fix action buttons not hiding

### DIFF
--- a/src/pages/paxDetail/changeHitStatus/ChangeHitStatus.js
+++ b/src/pages/paxDetail/changeHitStatus/ChangeHitStatus.js
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
-import { SplitButton, Dropdown, Button } from "react-bootstrap";
+import { Button } from "react-bootstrap";
 import RoleAuthenticator from "../../../context/roleAuthenticator/RoleAuthenticator";
 import Xl8 from "../../../components/xl8/Xl8";
 import { ROLE } from "../../../utils/constants";


### PR DESCRIPTION
#275 - fix `create hit` and `add to watchlist` action buttons showing up for the wrong roles. Previous fixes overlooked this in the original PR. When logged as View Passenger role, the red buttons still show up even though you can't click them.

![image](https://user-images.githubusercontent.com/49160279/102127251-486b5e80-3e1a-11eb-85a8-b68e3c5922bc.png)

To test:
- login as a view passenger role and verify that the red `create hit` and `add to watchlist` buttons are not visible.
- login as a manage watchlist role and verify that the red `add to watchlist` button IS visible but not the 'create manual hits'