### PR TITLE
fix null analyzed date

### DIFF
--- a/src/pages/admin/loaderStats/LoaderStats.js
+++ b/src/pages/admin/loaderStats/LoaderStats.js
@@ -14,7 +14,6 @@ const LoaderStats = ({ name }) => {
 
   const parseData = function(res) {
     const drools = res?.lastMessageAnalyzedByDrools;
-    console.log(drools);
     const parsedData = {
       ...res,
       lastMessageInSystem: localeDate(res?.lastMessageInSystem),

--- a/src/pages/admin/loaderStats/LoaderStats.js
+++ b/src/pages/admin/loaderStats/LoaderStats.js
@@ -11,13 +11,14 @@ import { localeDate } from "../../../utils/utils";
 const LoaderStats = ({ name }) => {
   const onChange = function(result) {};
   const cb = () => {};
-  const [key, setKey] = useState(0);
 
   const parseData = function(res) {
+    const drools = res?.lastMessageAnalyzedByDrools;
+    console.log(drools);
     const parsedData = {
       ...res,
-      lastMessageAnalyzedByDrools: localeDate(res?.lastMessageAnalyzedByDrools),
       lastMessageInSystem: localeDate(res?.lastMessageInSystem),
+      lastMessageAnalyzedByDrools: drools > 0 ? localeDate(drools) : " -- ",
       mostRecentRuleHit: localeDate(res?.mostRecentRuleHit)
     };
 
@@ -31,7 +32,6 @@ const LoaderStats = ({ name }) => {
       <Container>
         <Col lg={{ span: 4, offset: 4 }}>
           <Form
-            key={key}
             getService={loaderStats.get}
             title=""
             callback={cb}

--- a/src/pages/admin/loaderStats/LoaderStats.js
+++ b/src/pages/admin/loaderStats/LoaderStats.js
@@ -8,17 +8,20 @@ import { Container, Col } from "react-bootstrap";
 import Title from "../../../components/title/Title";
 import { localeDate } from "../../../utils/utils";
 
-const LoaderStats = ({ name }) => {
-  const onChange = function(result) {};
+const LoaderStats = () => {
+  const onChange = () => {};
   const cb = () => {};
 
   const parseData = function(res) {
     const drools = res?.lastMessageAnalyzedByDrools;
+    const msg = res?.lastMessageInSystem;
+    const hit = res?.mostRecentRuleHit;
+
     const parsedData = {
       ...res,
-      lastMessageInSystem: localeDate(res?.lastMessageInSystem),
+      lastMessageInSystem: msg > 0 ? localeDate(msg) : " -- ",
       lastMessageAnalyzedByDrools: drools > 0 ? localeDate(drools) : " -- ",
-      mostRecentRuleHit: localeDate(res?.mostRecentRuleHit)
+      mostRecentRuleHit: hit > 0 ? localeDate(hit) : " -- "
     };
 
     return parsedData;


### PR DESCRIPTION
fixes #412 

Prevent 0 date timestamps from being converted to 1970 date. Showing "--" instead.

also removed unnecessary form refresh token.

Can only be tested on a fresh install with no rules/hits/messages run.