### PR TITLE
fix duplicate redirect to login

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -153,12 +153,12 @@ const LanguageEditor = loadable(() =>
 );
 
 const NEO4JURL = window?._env_
-    ? window._env_.REACT_APP_NEO4J_BROWSER
-    : process.env.REACT_APP_NEO4J_BROWSER;
+  ? window._env_.REACT_APP_NEO4J_BROWSER
+  : process.env.REACT_APP_NEO4J_BROWSER;
 
 const KIBANAURL = window?._env_
-    ? window._env_.REACT_APP_BASE_KIBANA_LOGIN
-    : process.env.REACT_APP_KIBANA_LOGIN;
+  ? window._env_.REACT_APP_BASE_KIBANA_LOGIN
+  : process.env.REACT_APP_KIBANA_LOGIN;
 
 const App = props => {
   const [showModal, setShowModal] = useState(false);

--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -42,8 +42,8 @@ const Header = () => {
   const currentPath = useLocation();
 
   const logout = () => {
-    userAction({ type: "logoff" });
     action({ type: "read" });
+    userAction({ type: "logoff" });
 
     navigate(FULLPATH_TO.LOGIN);
   };
@@ -183,7 +183,7 @@ const Header = () => {
                 {<Xl8 xid="head005">Change password</Xl8>}
               </NavDropdown.Item>
               <NavDropdown.Divider />
-              <NavDropdown.Item as={Link} to="#" onClick={logout}>
+              <NavDropdown.Item onClick={logout}>
                 {<Xl8 xid="head006">Logout</Xl8>}
               </NavDropdown.Item>
             </NavDropdown>

--- a/src/pages/login/Login.js
+++ b/src/pages/login/Login.js
@@ -4,17 +4,20 @@ import Form from "../../components/form/Form";
 import LabelledInput from "../../components/labelledInput/LabelledInput";
 import { navigate, Link } from "@reach/router";
 import { UserContext } from "../../context/user/UserContext";
+import { LiveEditContext } from "../../context/translation/LiveEditContext";
 import { login } from "../../services/serviceWrapper";
-import { Alert, Card, Button } from "react-bootstrap";
+import { Alert, Button } from "react-bootstrap";
 
 import "./Login.scss";
 import { FULLPATH_TO } from "../../utils/constants";
 
 const Login = () => {
   const ctx = useContext(UserContext);
+  const { action } = useContext(LiveEditContext);
   const [alertVis, setAlertVis] = useState(false);
 
   useEffect(() => {
+    action({ type: "read" });
     ctx.userAction({ type: "logoff" });
   }, []);
 

--- a/src/pages/login/SignUp.js
+++ b/src/pages/login/SignUp.js
@@ -60,8 +60,8 @@ const SignUp = props => {
                   approval.
                 </Xl8>
               </Alert>
-              <Link to="/">
-                <Xl8 xid="sup010">Home</Xl8>
+              <Link to={FULLPATH_TO.LOGIN}>
+                <Xl8 xid="sup010">Login</Xl8>
               </Link>
             </>
           ) : (


### PR DESCRIPTION
Fix duplicate redirect/link when logging out which was causing an infinite loop.
Fix blank sign-up page link.
Added redundant logout and exit live edit code handle direct navs to login page

Fixes #597 #592 
