### PR TITLE
Updated the key value on the row element

### DIFF
--- a/src/components/table/Table.js
+++ b/src/components/table/Table.js
@@ -242,7 +242,7 @@ const Table = props => {
                 const sendRowToLink = !isGroupBy ? row.original.sendRowToLink : "";
                 const linked = link ? "linked" : "";
                 return (
-                  <tr {...row.getRowProps()} className={linked} key={row.original.id}>
+                  <tr {...row.getRowProps()} className={linked} key= {!isGroupBy ? row.original.id : row.groupByVal}>
                     {row.cells.map(cell => {
                       const style = cell.column.className || "";
                       if (link) {


### PR DESCRIPTION
-Key value on the row elements for when rows were aggregated wasn't present so it failed to construct both the rows themselves and the expanded sub-rows
-Key value now checks for if "isgroupBy" and assigns the key from that row's groupByVal instead.