### PR TITLE
Added initial state for vetting filter form

### DIFF
--- a/src/pages/vetting/Vetting.js
+++ b/src/pages/vetting/Vetting.js
@@ -245,6 +245,10 @@ const Vetting = props => {
   //   setFilterFormKey(filterFormKey + 1);
   // };
 
+  const getInitialState = () => {
+    return initialParamState;
+  }
+
   const changeStatus = (paxId, status) => {
     const newStatus =
       status === HIT_STATUS.REVIEWED ? HIT_STATUS.REOPENED : HIT_STATUS.REVIEWED;
@@ -382,7 +386,7 @@ const Vetting = props => {
             callback={setDataWrapper}
             paramCallback={parameterAdapter}
             key={filterFormKey}
-            // getInitialState={getInitialState}
+            getInitialState={getInitialState}
           >
             <LabelledInput
               datafield="myRulesOnly"


### PR DESCRIPTION
-Filter form reset button destroys all fields, then uses an init param function to fill if it exists
-vetting filter required more fields than other filters, hence why flight filter does not have problems
-added init params to init param call back to give default search on reset press.