### PR TITLE
Adds missing header to attachments

### DIFF
--- a/src/services/baseService.js
+++ b/src/services/baseService.js
@@ -24,6 +24,7 @@ const BASE_URL = window?._env_
   : process.env.REACT_APP_BASE_URL;
 
 export const BASEHEADER = { "Content-Type": JSONUTF8, Router: "api", Accept: AJSON };
+export const BASEFILEHEADER = { Router: "api", Accept: AJSON}
 
 export const stringify = body => {
   return JSON.stringify({ ...body });

--- a/src/services/serviceWrapper.js
+++ b/src/services/serviceWrapper.js
@@ -4,6 +4,7 @@
 
 import { get, put, post, del, putNoId } from "./genericService";
 import BASE_URL, {
+  BASEFILEHEADER,
   BASEHEADER,
   LOGINHEADER,
   SIGNUPHEADER,
@@ -207,7 +208,7 @@ export const attachment = {
       window.open(path, "_self");
     }
   },
-  post: body => post(ATTACHMENTS, "", body),
+  post: body => post(ATTACHMENTS, BASEFILEHEADER, body),
   del: attachmentId => {
     return del(ATTACHMENTS, BASEHEADER, attachmentId);
   }


### PR DESCRIPTION
-file uploads needs a special header, trying to assign content-type prevents the webkit form boundary from being used automatically as part of the content-type. The multipart file endpoint requires boundaries to be able to be read successfully. The easiest way to do this is to let the form automatically generate the content-type for this request. I.E. we have a header with no content-type for file uploads.