### PR TITLE
Fix for download attachment bug

### DIFF
--- a/src/pages/admin/fileDownload/FileDownload.js
+++ b/src/pages/admin/fileDownload/FileDownload.js
@@ -62,7 +62,7 @@ const FileDownload = ({ name }) => {
   };
 
   const downloadFile = rowDetails => {
-    logfile.download(currentLogType + "/" + rowDetails.fileName);
+    logfile.download(currentLogType + "/" + rowDetails.fileName, rowDetails.fileName);
   };
 
   const headers = [

--- a/src/pages/paxDetail/uploadAttachment/UploadAttachment.js
+++ b/src/pages/paxDetail/uploadAttachment/UploadAttachment.js
@@ -29,7 +29,7 @@ const UploadAttachment = props => {
   };
 
   const downloadAttachment = row => {
-    attachment.get.download(row.id);
+    attachment.get.download(row.id, row.filename);
   };
 
   useEffect(() => {

--- a/src/services/genericService.js
+++ b/src/services/genericService.js
@@ -31,6 +31,7 @@ export const GenericService = async props => {
       if (response.ok) {
         if (response.url.endsWith("/authenticate")) return response;
         if (response.url.includes("paxdetailreport")) return response.arrayBuffer();
+        if (response.url.includes("attachmentId") || (response.url.includes("logs") && props.uri.split("/").length === 8)) return response.blob();
         return response.json().then(res => res.data || res || response);
       } else {
         return response;
@@ -84,3 +85,15 @@ export const del = (uri, headers, id) => {
     headers: headers
   });
 };
+
+export const downloadWrap = (blob, fileName) => {
+  var tempEl = document.createElement("a");
+  document.body.appendChild(tempEl);
+  tempEl.style = "display: none";
+  var url = window.URL.createObjectURL(blob);
+  tempEl.href = url;
+  tempEl.download = fileName;
+  tempEl.click();
+  window.URL.revokeObjectURL(url);
+  tempEl.remove();
+}

--- a/src/services/serviceWrapper.js
+++ b/src/services/serviceWrapper.js
@@ -2,7 +2,7 @@
 //
 // Please see license.txt for details.
 
-import { get, put, post, del, putNoId } from "./genericService";
+import {get, put, post, del, putNoId, downloadWrap} from "./genericService";
 import BASE_URL, {
   BASEFILEHEADER,
   BASEHEADER,
@@ -203,9 +203,12 @@ export const attachment = {
       const path = ATTACHMENTSMETA + `?paxId=${paxId}`;
       return get(path, BASEHEADER);
     },
-    download: attachmentId => {
+    download: (attachmentId, fileName) => {
       const path = DOWNLOADATTACHMENT + `?attachmentId=${attachmentId}`;
-      window.open(path, "_self");
+      get(path, BASEFILEHEADER, true).then(res =>{
+        downloadWrap(res, fileName);
+      });
+      //window.open(path, "_self");
     }
   },
   post: body => post(ATTACHMENTS, BASEFILEHEADER, body),
@@ -319,7 +322,12 @@ export const manualHit = {
 
 export const logfile = {
   get: (id, params) => get(LOGFILE, BASEHEADER, id, params),
-  download: params => window.open(LOGFILE + params, "_self")
+  download: (params, fileName) => {
+    get(LOGFILE+params, BASEHEADER).then(res=>{
+      downloadWrap(res, fileName);
+    });
+    //window.open(LOGFILE + params, "_self")
+  }
 };
 
 export const changePassword = {


### PR DESCRIPTION
-window.open is problematic for when we try to pass custom headers due to its locked down nature
-replaced window.open with normal response entity service call
-made download wrapper in order to pass response entity (blob) to, to create the normal download window trigger.
-need to pass filename through service now for things that initiate a 'download'
-Same bug existed on log files, this should be fixed by that.
-generic service modified for given urls to convert response to blob when appropriate

fixes #643 
