### PR TITLE
Update the way wl dates are parsed to a string.

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -362,11 +362,10 @@ export function formatRuleConditions(conditions) {
 export const watchlistDateFormat = input => {
   const stringDate = new Date(input);
   if (stringDate === "Invalid Date") return "Invalid Date";
-  const day = stringDate.getDate(); // use getDate(). getDay() returns the day of the week
-  const month = stringDate.getMonth() + 1; // 0 based
-  const year = stringDate.getFullYear();
-
-  return `${year}-${month}-${day}`;
+  const formattedDate = stringDate.getFullYear() 
+  + '-' + ('0' + (stringDate.getMonth()+1)).slice(-2) 
+  + '-' + ('0' + stringDate.getDate()).slice(-2);
+  return formattedDate;
 };
 
 export const lpad5 = val => {


### PR DESCRIPTION
Describe the bug
A clear and concise description of what the bug is.
Watchlist Imports Date Without 0

To Reproduce
Steps to reproduce the behavior:
Import watchlist, review wl_item database, review dob field.

Expected behavior
dob field in watchlist item has preceding 0s where appropriate.

e.g. 1982-02-02 instead of 1982-2-2

Additional context
Ticket for GUI
#654
Companion ticket in GTAS
US-CBP/GTAS#2016

A leading 0 must be applied to dates otherwise the fuzzy matching GTAS
uses has an error parsing dates from watchlist items.