### PR TITLE
reset dp layout, fix background scroll behavior

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -375,8 +375,8 @@ li .rtf--ab__c button[variant="rtf-red"] {
 .filter-fg-open {
   color: #f8f9fa;
   z-index: 10;
-  overflow-y: auto;
-  overflow-x: hidden;
+  // overflow-y: auto;
+  // overflow-x: hidden;
 }
 
 .filter-fg::-webkit-scrollbar-thumb,
@@ -389,12 +389,10 @@ li .rtf--ab__c button[variant="rtf-red"] {
 .filter-fg > .col,
 .filter-fg-open > .col {
   margin-top: 20px;
-  -webkit-backdrop-filter: blur(5px);
-  backdrop-filter: blur(5px);
-  // border-radius: 0.5rem;
+  backdrop-filter: blur(2px);
   padding-bottom: 5px;
   padding: 0px;
-  background-color: #40404022;
+  height: 100%;
 }
 
 @media (max-width: 1024px) {

--- a/src/components/filterForm2/FilterForm.css
+++ b/src/components/filterForm2/FilterForm.css
@@ -7,16 +7,18 @@
 .filterform-container {
   overflow-x: hidden;
   overflow-y: auto;
+  height: 100%;
 }
 
 .filterform-container .react-calendar {
   position: fixed;
   top: auto;
   line-height: 0.5rem;
-  width: 240px !important;
   border-radius: 5px;
   display: block;
   max-width: unset;
+  left: 240px;
+  bottom: 5px;
 }
 
 .input:optional {

--- a/src/components/filterForm2/FilterForm.css
+++ b/src/components/filterForm2/FilterForm.css
@@ -18,7 +18,8 @@
   display: block;
   max-width: unset;
   left: 240px;
-  bottom: 5px;
+  max-height: 300px;
+  overflow-y: scroll;
 }
 
 .input:optional {


### PR DESCRIPTION
fixes #642 - makes the datepicker calendar popups fully visible for all data/views.

popped the calendar popup out of the sidebar, and then had to adjust the parent containers to re-enable the vertical scrollbar for short viewports.

To Test:
1. go to the vetting page
2. select "Show Date Time picker"
3. click on the year, month or day portion of the date to launch the calendar and verify you can view all days in the month
4. click the popup header (month YYYY) and verify you can view all months in the year
5. keep clicking the header and ensure you can view all years or year groups
6. drag the browser edge to make the window shorter vertically so it hides at least the Reset and Search buttons and ensure that the sidebar displays a scrollbar so that all the contents are still accessible

![datepickerlayout](https://user-images.githubusercontent.com/49160279/108920826-57814080-7603-11eb-859a-9ea6223e7a3b.JPG)
