### PR TITLE
null check on search comparison

### DIFF
--- a/src/components/seatChart/searchSeat/SearchSeat.js
+++ b/src/components/seatChart/searchSeat/SearchSeat.js
@@ -4,11 +4,11 @@
 
 import React from "react";
 import { Form, Button } from "react-bootstrap";
-import { asArray, hasData } from "../../../utils/utils";
+import { asArray, hasData, alt } from "../../../utils/utils";
 
 const SearchSeat = ({ searchCallback, reservedSeats, resetFilterForm }, ref) => {
   const areEqual = (str1, str2) => {
-    return str1.toUpperCase() === str2.toUpperCase();
+    return alt(str1).toUpperCase() === alt(str2).toUpperCase();
   };
 
   const reset = () => {


### PR DESCRIPTION
Fixes #632 Seat search middle name not working

Minor. `areEqual` does a toUpperCase on the input params which fails silently if either is null. Just added the `alt` fxn.