### PR TITLE
set the initial state for the signup request filterform

### DIFF
--- a/src/pages/admin/signUpRequests/SignUpRequests.js
+++ b/src/pages/admin/signUpRequests/SignUpRequests.js
@@ -154,6 +154,10 @@ const SignUpRequests = () => {
     { Accessor: "status", Xl8: true, Header: ["sur012", "Status"] }
   ];
 
+  const initialParamState = () => {
+    return { username: "", status: "NEW", location: "" };
+  };
+
   return (
     <>
       <SidenavContainer>
@@ -163,6 +167,7 @@ const SignUpRequests = () => {
             paramCallback={preFetchCallback}
             callback={setDataWrapper}
             key={fetchData}
+            getInitialState={initialParamState}
           >
             <LabelledInput
               labelText={<Xl8 xid="sur003">Username</Xl8>}


### PR DESCRIPTION
fixes #650 - Reset not displaying the correct results

Set the initial form data to select signup requests in the "NEW" status by default.