### PR TITLE
CardWithTable - don't return overlays for fields without tooltips

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -501,3 +501,25 @@ li .rtf--ab__c button[variant="rtf-red"] {
 .tooltip.show {
   opacity: 1 !important ;
 }
+
+.sidebar-tooltip > .tooltip-inner {
+  background-color: white;
+}
+
+.overlay-content {
+  background-color: #575756;
+  color: white !important;
+  border-radius: 0.3rem;
+  text-align: center;
+}
+
+.overlay-content-light {
+  color: #575756;
+  background-color: white !important;
+  border-radius: 0.3rem;
+  text-align: center;
+}
+
+.popover {
+  border-radius: 0.5rem !important;
+}

--- a/src/App.scss
+++ b/src/App.scss
@@ -243,10 +243,9 @@ input[type="radio"] {
   color: #008177;
 }
 
-.overlay-content {
-  background-color: white !important;
-  border: 1px solid #009e92 !important;
-  border-radius: 0.25rem;
+.bs-popover-top > .arrow::after,
+.bs-popover-auto[x-placement^="top"] > .arrow::after {
+  border-top-color: #575756 !important;
 }
 
 .img-arrival {
@@ -485,4 +484,20 @@ li .rtf--ab__c button[variant="rtf-red"] {
   box-shadow: 0 0 0 0.2rem red;
   outline: 0;
   border-radius: 3px;
+}
+
+.tooltip-inner {
+  background-color: #575756 !important;
+  opacity: 1;
+}
+
+.bs-tooltip-top .arrow::before,
+.bs-tooltip-auto[x-placement^="top"] .arrow::before {
+  top: 0;
+  border-width: 0.4rem 0.4rem 0;
+  border-top-color: #575756 !important;
+}
+
+.tooltip.show {
+  opacity: 1 !important ;
 }

--- a/src/components/cardWithTable/CardWithTable.js
+++ b/src/components/cardWithTable/CardWithTable.js
@@ -43,25 +43,25 @@ const CardWithTable = props => {
       const td = row[key];
       const triggerOverlay = !isShortText(td, textDisplayLimit);
       const triggerTooltip = needsTooltip(key);
-      return triggerTooltip
-        ? [
-            <td className="cardwithtable-tooltip">
-              <ToolTipWrapper data={{ val: td, lkup: toolTipLKMap[key] }}>
-                {getShortText(td, textDisplayLimit)}
-              </ToolTipWrapper>
-            </td>
-          ]
-        : [
-            <Overlay
-              trigger={triggerOverlay ? ["click", "hover"] : ""}
-              key={key}
-              content={td}
-            >
-              <td className={triggerOverlay ? "as-info" : ""}>
-                {getShortText(td, textDisplayLimit)}
-              </td>
-            </Overlay>
-          ];
+      return triggerTooltip ? (
+        <td className="as-info">
+          <ToolTipWrapper data={{ val: td, lkup: toolTipLKMap[key] }}>
+            {getShortText(td, textDisplayLimit)}
+          </ToolTipWrapper>
+        </td>
+      ) : triggerOverlay ? (
+        <Overlay
+          trigger={triggerOverlay ? ["click", "hover"] : ""}
+          key={key}
+          content={td}
+        >
+          <td className={triggerOverlay ? "as-info" : ""}>
+            {getShortText(td, textDisplayLimit)}
+          </td>
+        </Overlay>
+      ) : (
+        <td>{td}</td>
+      );
     });
 
     return (

--- a/src/components/overlay/Overlay.scss
+++ b/src/components/overlay/Overlay.scss
@@ -5,7 +5,9 @@
 $transparent: rgba(133, 130, 130, 0.6);
 
 .overlay-content {
-  background-color: $transparent;
+  background-color: #575756;
+  color: white !important;
+  border-radius: 0.25rem;
   text-align: center;
 }
 

--- a/src/components/overlay/Overlay.scss
+++ b/src/components/overlay/Overlay.scss
@@ -4,13 +4,6 @@
 
 $transparent: rgba(133, 130, 130, 0.6);
 
-.overlay-content {
-  background-color: #575756;
-  color: white !important;
-  border-radius: 0.25rem;
-  text-align: center;
-}
-
 .bs-popover-top {
   z-index: 12000;
 }

--- a/src/components/paxInfo/PaxInfo.js
+++ b/src/components/paxInfo/PaxInfo.js
@@ -34,6 +34,7 @@ const PaxInfo = props => {
         label: <Xl8 xid="pd013">Nationality</Xl8>,
         value: (
           <ToolTipWrapper
+            className="overlay-content-light"
             data={{ val: res.nationality, lkup: LK.COUNTRY }}
           ></ToolTipWrapper>
         )

--- a/src/components/stepper/Stepper.js
+++ b/src/components/stepper/Stepper.js
@@ -71,9 +71,9 @@ const Stepper = props => {
                 style={{ width: 100 / steps.length + "%" }}
                 key={index}
               >
-                <ToolTipWrapper data={{ val: step.label, lkup: LK.AIRPORT }}>
-                  className="sm"
-                </ToolTipWrapper>
+                <ToolTipWrapper
+                  data={{ val: step.label, lkup: LK.AIRPORT }}
+                ></ToolTipWrapper>
               </li>
             ))}
           </ul>

--- a/src/components/tooltipWrapper/TooltipWrapper.js
+++ b/src/components/tooltipWrapper/TooltipWrapper.js
@@ -12,11 +12,7 @@ const ToolTipWrapper = props => {
   const initToolTipState = "Loading...";
   const [toolTipVal, setToolTipVal] = useState(initToolTipState);
 
-  const renderTooltip = props => (
-    <Tooltip id="tooltipWrapper-tooltip" {...props}>
-      {toolTipVal}
-    </Tooltip>
-  );
+  const renderTooltip = props => <Tooltip {...props}>{toolTipVal}</Tooltip>;
 
   const getToolTipValue = (val, codeType) => {
     setToolTipVal(initToolTipState);
@@ -42,7 +38,7 @@ const ToolTipWrapper = props => {
       delay={{ show: data.show, hide: data.hide }}
       onEnter={() => getToolTipValue(data.val, data.lookup)}
       //onExited={() => setToolTipVal(initToolTipState)}
-      overlay={renderTooltip()}
+      overlay={renderTooltip}
     >
       <span>{data.val}</span>
     </OverlayTrigger>

--- a/src/components/tooltipWrapper/TooltipWrapper.js
+++ b/src/components/tooltipWrapper/TooltipWrapper.js
@@ -22,6 +22,7 @@ const ToolTipWrapper = props => {
   );
 
   const getToolTipValue = () => {
+    setToolTipVal(initToolTipState);
     getCachedKeyValues(lkup).then(types => {
       const type = asArray(types).find(t => {
         return t.value === val;

--- a/src/components/tooltipWrapper/TooltipWrapper.js
+++ b/src/components/tooltipWrapper/TooltipWrapper.js
@@ -2,21 +2,27 @@
 //
 // Please see license.txt for details.
 
-import React, { useContext, useState } from "react";
+import React, { useContext, useState, useMemo } from "react";
 import { asArray, hasData } from "../../utils/utils";
-import { OverlayTrigger, Tooltip } from "react-bootstrap";
+import { OverlayTrigger, Popover } from "react-bootstrap";
 import { LookupContext } from "../../context/data/LookupContext";
 
 const ToolTipWrapper = props => {
+  const className = props?.className || "overlay-content";
   const { getCachedKeyValues } = useContext(LookupContext);
   const initToolTipState = "Loading...";
   const [toolTipVal, setToolTipVal] = useState(initToolTipState);
+  const val = props.data.val;
+  const lkup = props.data.lkup;
 
-  const renderTooltip = props => <Tooltip {...props}>{toolTipVal}</Tooltip>;
+  const renderTooltip = props => (
+    <Popover {...props}>
+      <Popover.Content className={className}>{toolTipVal}</Popover.Content>
+    </Popover>
+  );
 
-  const getToolTipValue = (val, codeType) => {
-    setToolTipVal(initToolTipState);
-    getCachedKeyValues(codeType).then(types => {
+  const getToolTipValue = () => {
+    getCachedKeyValues(lkup).then(types => {
       const type = asArray(types).find(t => {
         return t.value === val;
       });
@@ -25,8 +31,8 @@ const ToolTipWrapper = props => {
   };
 
   const data = {
-    val: props.data.val,
-    lookup: props.data.lkup,
+    val: val,
+    lookup: lkup,
     placement: hasData(props.data.placement) ? props.data.placement : "top",
     show: hasData(props.data.show) ? props.data.show : 250,
     hide: hasData(props.data.hide) ? props.data.hide : 400
@@ -36,7 +42,7 @@ const ToolTipWrapper = props => {
     <OverlayTrigger
       placement={data.placement}
       delay={{ show: data.show, hide: data.hide }}
-      onEnter={() => getToolTipValue(data.val, data.lookup)}
+      onEnter={getToolTipValue}
       //onExited={() => setToolTipVal(initToolTipState)}
       overlay={renderTooltip}
     >

--- a/src/pages/flightPax/FlightPax.js
+++ b/src/pages/flightPax/FlightPax.js
@@ -229,9 +229,9 @@ const FlightPax = props => {
       disableGroupBy: true,
       Cell: ({ row }) => {
         return (
-          <ToolTipWrapper data={{ val: row.original.nationality, lkup: LK.COUNTRY }}>
-            className="sm"
-          </ToolTipWrapper>
+          <ToolTipWrapper
+            data={{ val: row.original.nationality, lkup: LK.COUNTRY }}
+          ></ToolTipWrapper>
         );
       },
       Aggregated: () => ``

--- a/src/pages/flights/Flights.js
+++ b/src/pages/flights/Flights.js
@@ -213,9 +213,9 @@ const Flights = props => {
       Header: ["fl020", "Origin"],
       Cell: ({ row }) => (
         <>
-          <ToolTipWrapper data={{ val: row.original.origin, lkup: LK.AIRPORT }}>
-            className="sm"
-          </ToolTipWrapper>
+          <ToolTipWrapper
+            data={{ val: row.original.origin, lkup: LK.AIRPORT }}
+          ></ToolTipWrapper>
         </>
       )
     },
@@ -225,9 +225,9 @@ const Flights = props => {
       Header: ["fl021", "Destination"],
       Cell: ({ row }) => (
         <>
-          <ToolTipWrapper data={{ val: row.original.destination, lkup: LK.AIRPORT }}>
-            className="sm"
-          </ToolTipWrapper>
+          <ToolTipWrapper
+            data={{ val: row.original.destination, lkup: LK.AIRPORT }}
+          ></ToolTipWrapper>
         </>
       )
     },


### PR DESCRIPTION
Fixes #678 - This is a very minor fix, but impacts performance. Just added a second test to CardWithTable to display a plain <td> element rather than defaulting to either of the tooltip components.

Also updated the css for both tooltip implementations to use the dark popover style and green link text.

Ran a few dozen tests comparing them, and was able to reduce the the paxdetail page cpu load spike (where the cpu was above 5% on page load) from a range of 8 - 10 seconds down to 4 - 6 seconds. Peak cpu seconds (at 100%) went from 4-5 seconds down to 1-3 seconds (avg about 2.2) over 11 tests. Also ran several lighthouse reports against the two, and while most metrics were more or less a wash, the time to interactive ranged from .8 seconds to 3.3 seconds faster with the latest changes. Lots of hard to control variables, tho, so pls run your own tests to see if you can reproduce.

  