### PR TITLE
upgrade react bootstrap to 1.5.0 from rc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3139,9 +3139,9 @@
       }
     },
     "@popperjs/core": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.5.4.tgz",
-      "integrity": "sha512-ZpKr+WTb8zsajqgDkvCEWgp6d5eJT6Q63Ng2neTbzBO76Lbe91vX/iVIW9dikq+Fs3yEo+ls4cxeXABD2LtcbQ=="
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.8.4.tgz",
+      "integrity": "sha512-h0lY7g36rhjNV8KVHKS3/BEOgfsxu0AiRI8+ry5IFBGEsQFkpjxtcpVc9ndN8zrKUeMZXAWMc7eQMepfgykpxQ=="
     },
     "@reach/router": {
       "version": "1.3.4",
@@ -3160,12 +3160,24 @@
       "integrity": "sha512-INJYZQJP7g+IoDUh/475NlGiTeMfwTXUEr3tmRneckHIxNolGOW9CTq83S8cxq0CgJwwcMzMJFchxvlwe7Rk8Q=="
     },
     "@restart/hooks": {
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.3.25.tgz",
-      "integrity": "sha512-m2v3N5pxTsIiSH74/sb1yW8D9RxkJidGW+5Mfwn/lHb2QzhZNlaU1su7abSyT9EGf0xS/0waLjrf7/XxQHUk7w==",
+      "version": "0.3.26",
+      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.3.26.tgz",
+      "integrity": "sha512-7Hwk2ZMYm+JLWcb7R9qIXk1OoUg1Z+saKWqZXlrvFwT3w6UArVNWgxYOzf+PJoK9zZejp8okPAKTctthhXLt5g==",
       "requires": {
-        "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15"
+        "lodash": "^4.17.20",
+        "lodash-es": "^4.17.20"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
+        "lodash-es": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+          "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+        }
       }
     },
     "@rollup/plugin-node-resolve": {
@@ -3667,9 +3679,9 @@
       }
     },
     "@types/classnames": {
-      "version": "2.2.10",
-      "resolved": "https://registry.npmjs.org/@types/classnames/-/classnames-2.2.10.tgz",
-      "integrity": "sha512-1UzDldn9GfYYEsWWnn/P4wkTlkZDH7lDb0wBMGbtIQc9zXEQq7FlKBdZUn6OBqD8sKZZ2RQO2mAjGpXiDGoRmQ=="
+      "version": "2.2.11",
+      "resolved": "https://registry.npmjs.org/@types/classnames/-/classnames-2.2.11.tgz",
+      "integrity": "sha512-2koNhpWm3DgWRp5tpkiJ8JGc1xTn2q0l+jUNUE7oMKXUf5NpI9AIdC4kbjGNFBdHtcxBD18LAksoudAVhFKCjw=="
     },
     "@types/eslint": {
       "version": "7.2.6",
@@ -3708,9 +3720,9 @@
       "integrity": "sha512-giAlZwstKbmvMk1OO7WXSj4OZ0keXAcl2TQq4LWHiiPH2ByaH7WeUzng+Qej8UPxxv+8lRTuouo0iaNDBuzIBA=="
     },
     "@types/invariant": {
-      "version": "2.2.33",
-      "resolved": "https://registry.npmjs.org/@types/invariant/-/invariant-2.2.33.tgz",
-      "integrity": "sha512-/jUNmS8d4bCKdqslfxW6dg/9Gksfzxz67IYfqApHn+HvHlMVXwYv2zpTDnS/yaK9BB0i0GlBTaYci0EFE62Hmw=="
+      "version": "2.2.34",
+      "resolved": "https://registry.npmjs.org/@types/invariant/-/invariant-2.2.34.tgz",
+      "integrity": "sha512-lYUtmJ9BqUN688fGY1U1HZoWT1/Jrmgigx2loq4ZcJpICECm/Om3V314BxdzypO0u5PORKGMM6x0OXaljV1YFg=="
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
@@ -3817,9 +3829,9 @@
       }
     },
     "@types/react-transition-group": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.0.tgz",
-      "integrity": "sha512-/QfLHGpu+2fQOqQaXh8MG9q03bFENooTb/it4jr5kKaZlDQfWvjqWZg48AwzPVMBHlRuTRAY7hRHCEOXz5kV6w==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.1.tgz",
+      "integrity": "sha512-vIo69qKKcYoJ8wKCJjwSgCTM+z3chw3g18dkrDfVX665tMH7tmbDxEAnPdey4gTlwZz5QuHGzd+hul0OVZDqqQ==",
       "requires": {
         "@types/react": "*"
       }
@@ -17409,9 +17421,9 @@
       }
     },
     "react-bootstrap": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-1.2.2.tgz",
-      "integrity": "sha512-G+QcEyBqFtakBNghdDugie+yU/ABDeqw3n+SOeRGxEn1m0dbIyHTroZpectcQk6FB3aS4RJGkZTuLVYH86Cu2A==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-1.5.0.tgz",
+      "integrity": "sha512-t1o4kP3coj2HIaBepJxGAc7HZ1fWGria/s0Yr9JUmNkCilyrnXtK209qn28vuZ4muhnA0uR0GMMXAMrLsLyiIw==",
       "requires": {
         "@babel/runtime": "^7.4.2",
         "@restart/context": "^2.1.4",
@@ -17419,7 +17431,7 @@
         "@types/classnames": "^2.2.10",
         "@types/invariant": "^2.2.33",
         "@types/prop-types": "^15.7.3",
-        "@types/react": "^16.9.35",
+        "@types/react": ">=16.9.35",
         "@types/react-transition-group": "^4.4.0",
         "@types/warning": "^3.0.0",
         "classnames": "^2.2.6",
@@ -17427,8 +17439,8 @@
         "invariant": "^2.2.4",
         "prop-types": "^15.7.2",
         "prop-types-extra": "^1.1.0",
-        "react-overlays": "^4.0.0",
-        "react-transition-group": "^4.0.0",
+        "react-overlays": "^4.1.1",
+        "react-transition-group": "^4.4.1",
         "uncontrollable": "^7.0.0",
         "warning": "^4.0.3"
       }
@@ -17876,18 +17888,34 @@
       }
     },
     "react-overlays": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-4.1.0.tgz",
-      "integrity": "sha512-vdRpnKe0ckWOOD9uWdqykLUPHLPndIiUV7XfEKsi5008xiyHCfL8bxsx4LbMrfnxW1LzRthLyfy50XYRFNQqqw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-4.1.1.tgz",
+      "integrity": "sha512-WtJifh081e6M24KnvTQoNjQEpz7HoLxqt8TwZM7LOYIkYJ8i/Ly1Xi7RVte87ZVnmqQ4PFaFiNHZhSINPSpdBQ==",
       "requires": {
-        "@babel/runtime": "^7.4.5",
-        "@popperjs/core": "^2.0.0",
-        "@restart/hooks": "^0.3.12",
+        "@babel/runtime": "^7.12.1",
+        "@popperjs/core": "^2.5.3",
+        "@restart/hooks": "^0.3.25",
         "@types/warning": "^3.0.0",
-        "dom-helpers": "^5.1.0",
+        "dom-helpers": "^5.2.0",
         "prop-types": "^15.7.2",
         "uncontrollable": "^7.0.0",
         "warning": "^4.0.3"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.7.tgz",
+          "integrity": "sha512-KxnUB0ZMlnUWCsx2Z8MUsr6qV6ja1w9ArPErJaJaF8a5SOWoHLIszeCTKGRGRgtLgYrs1E8CHkNSP1VZTTPc9g=="
+        },
+        "dom-helpers": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.0.tgz",
+          "integrity": "sha512-Ru5o9+V8CpunKnz5LGgWXkmrH/20cGKwcHwS4m73zIvs54CN9epEmT/HLqFJW3kXpakAFkEdzgy1hzlJe3E4OQ==",
+          "requires": {
+            "@babel/runtime": "^7.8.7",
+            "csstype": "^3.0.2"
+          }
+        }
       }
     },
     "react-papaparse": {
@@ -21897,12 +21925,12 @@
       }
     },
     "uncontrollable": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-7.1.1.tgz",
-      "integrity": "sha512-EcPYhot3uWTS3w00R32R2+vS8Vr53tttrvMj/yA1uYRhf8hbTG2GyugGqWDY0qIskxn0uTTojVd6wPYW9ZEf8Q==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-7.2.1.tgz",
+      "integrity": "sha512-svtcfoTADIB0nT9nltgjujTi7BzVmwjZClOmskKu/E8FW9BXzg9os8OLr4f8Dlnk0rYWJIWr4wv9eKUXiQvQwQ==",
       "requires": {
         "@babel/runtime": "^7.6.3",
-        "@types/react": "^16.9.11",
+        "@types/react": ">=16.9.11",
         "invariant": "^2.2.4",
         "react-lifecycles-compat": "^3.0.4"
       }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "react": "^16.12.0",
     "react-awesome-query-builder": "^2.1.9",
     "react-beautiful-dnd": "^13.0.0",
-    "react-bootstrap": "^1.0.0-beta.16",
+    "react-bootstrap": "^1.5.0",
     "react-datetime-picker": "^3.0.4",
     "react-dom": "^16.12.0",
     "react-i18next": "^11.7.2",

--- a/src/components/stepper/Stepper.js
+++ b/src/components/stepper/Stepper.js
@@ -6,7 +6,7 @@ import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { Row, Container } from "react-bootstrap";
 import "./Stepper.scss";
-import {LK} from "../../utils/constants";
+import { LK } from "../../utils/constants";
 import ToolTipWrapper from "../tooltipWrapper/TooltipWrapper";
 
 const Stepper = props => {
@@ -72,9 +72,8 @@ const Stepper = props => {
                 key={index}
               >
                 <ToolTipWrapper
-                    data={{val:step.label, lkup:LK.AIRPORT}}>
-                  className="sm"
-                </ToolTipWrapper>
+                  data={{ val: step.label, lkup: LK.AIRPORT }}
+                ></ToolTipWrapper>
               </li>
             ))}
           </ul>


### PR DESCRIPTION
bump bootstrap dep from the rc version. Just click around the app to verify bootstrap-related js and jquery still behave as expected (eg, the navbar dropdowns, popovers, modals, etc)

Fixes #690 