### PR TITLE
fix translation modal css

### DIFF
--- a/src/components/inputs/label/Label.js
+++ b/src/components/inputs/label/Label.js
@@ -8,7 +8,7 @@ import PropTypes from "prop-types";
 import "./Label.css";
 
 const LabelInput = props => {
-  const cls = props.className + (props.inline ? " inline" : " label");
+  const cls = props.className + (props.inline ? " inline" : "");
   return (
     <label className={cls} name={props.name} alt={props.alt}>
       {props.inputval}

--- a/src/components/labelledInput/LabelledInput.css
+++ b/src/components/labelledInput/LabelledInput.css
@@ -21,7 +21,23 @@
   width: unset !important;
   text-align: right;
   white-space: nowrap;
-  /* min-width: 90px; */
+  min-width: 30%;
+  margin-right: 10px;
+}
+
+.space-between-wrap > .label {
+  text-align: right;
+  display: block;
+  max-width: 65%;
+  float: right;
+  font-style: italic;
+  margin-bottom: 0.25rem !important;
+}
+
+.space-between-wrap .txtlabel {
+  width: unset !important;
+  text-align: right;
+  white-space: nowrap;
   min-width: 30%;
   margin-right: 10px;
 }

--- a/src/components/labelledInput/LabelledInput.js
+++ b/src/components/labelledInput/LabelledInput.js
@@ -116,7 +116,7 @@ class LabelledInput extends Component {
     if (type === "label") {
       return (
         <LabelInput
-          className={this.props.inputStyle}
+          className={inputStyle}
           alt={this.props.alt}
           name={this.props.name}
           inputval={this.props.inputval}
@@ -238,11 +238,12 @@ class LabelledInput extends Component {
   }
 
   render() {
-    const cls = !!this.props.spacebetween ? " space-between" : "";
+    const sb = !!this.props.spacebetween ? " space-between" : "";
+    const sbw = !!this.props.spacebetweenwrap ? " space-between-wrap" : "";
     const inline = !!this.props.inline ? " input-group-append" : "";
     const textlabelStyle = this.props.inputtype === "multiSelect" ? "" : "txtlabel";
     return (
-      <FormGroup className={`${this.state.visibleStyle}${cls}${inline}`}>
+      <FormGroup className={`${this.state.visibleStyle}${sb}${sbw}${inline}`}>
         <label className={textlabelStyle}>{this.state.labelText}</label>
         {this.getInputByType()}
       </FormGroup>

--- a/src/pages/home/LangModal.js
+++ b/src/pages/home/LangModal.js
@@ -73,7 +73,7 @@ const LangModal = props => {
               name="default"
               alt="Default Text"
               callback={cb}
-              spacebetween
+              spacebetweenwrap
             />
             <LabelledInput
               datafield


### PR DESCRIPTION
fixes #696 - Translation modal text running off the edge.

When the **Default Text** was long, it was not wrapping.

1. Turn on translation mode
2. Go to PaxDetail
3. click the "Add to Watchlist" fab button
4. click to edit the text on the Add modal

Looks like this now. Added italics so it stands out a bit more. Not sure how I feel about it.
![transmodallabel](https://user-images.githubusercontent.com/49160279/111702197-4a2a3100-8812-11eb-8b21-a7ce4341d6e6.JPG)

