### PR TITLE
Fix/seat chart translations

### DIFF
--- a/src/components/seatChart/SeatChart.js
+++ b/src/components/seatChart/SeatChart.js
@@ -132,10 +132,16 @@ const SeatChart = ({ location }) => {
       value: selectedSeatInfo.number
     }
   ];
-  const linkToFlightPax = <Link to={`/gtas/flightpax/${flightId}`}>Flightpax</Link>;
+  const linkToFlightPax = (
+    <Link to={`/gtas/flightpax/${flightId}`}>
+      <Xl8 xid="seat011">Show flight passengers</Xl8>
+    </Link>
+  );
 
   const linkToPaxdetails = (
-    <Link to={`/gtas/paxDetail/${flightId}/${paxId}`}>Show passenger details</Link>
+    <Link to={`/gtas/paxDetail/${flightId}/${paxId}`}>
+      <Xl8 xid="seat012">Show passenger details</Xl8>
+    </Link>
   );
 
   return (

--- a/src/components/seatChart/SeatChart.js
+++ b/src/components/seatChart/SeatChart.js
@@ -3,19 +3,19 @@
 // Please see license.txt for details.
 
 import React, { useEffect, useRef, useState } from "react";
-import Seat from "./seat/Seat";
-import { Container, Row, CardDeck, Card } from "react-bootstrap";
-import { seats } from "../../services/serviceWrapper";
-import { asArray, localeDate } from "../../utils/utils";
 import { Link, useParams } from "@reach/router";
+import Seat from "./seat/Seat";
 import Legend from "./legend/Legend";
 import SeatChartCard from "./seatChartCard/SeatChartCard";
 import Loading from "../loading/Loading";
 import Xl8 from "../xl8/Xl8";
-import "./SeatChart.scss";
 import SearchSeat from "./searchSeat/SearchSeat";
 import SidenavContainer from "../sidenavContainer/SidenavContainer";
 import Main from "../main/Main";
+import { seats } from "../../services/serviceWrapper";
+import { Row, CardDeck, Card } from "react-bootstrap";
+import { asArray, localeDate } from "../../utils/utils";
+import "./SeatChart.scss";
 
 const SeatChart = ({ location }) => {
   const { flightId, paxId, currentPaxSeat } = useParams();
@@ -34,6 +34,7 @@ const SeatChart = ({ location }) => {
       seat.classList.remove("search-result");
     });
   };
+
   const searchCallback = searchResult => {
     resetSearch();
     setSearchedSeats(searchResult);
@@ -43,6 +44,7 @@ const SeatChart = ({ location }) => {
       seat.focus();
     });
   };
+
   const getRow = letter => {
     const row = [];
     columnWithReservedSeat.forEach(col => {

--- a/src/components/seatChart/SeatChart.scss
+++ b/src/components/seatChart/SeatChart.scss
@@ -10,7 +10,9 @@
 .seat-chart .row {
   flex-wrap: nowrap;
   margin: 10px 0px;
+  justify-content: center;
 }
+
 .right-of-middle-rows {
   margin-top: 30px !important;
 }

--- a/src/components/seatChart/SeatChart.scss
+++ b/src/components/seatChart/SeatChart.scss
@@ -10,7 +10,6 @@
 .seat-chart .row {
   flex-wrap: nowrap;
   margin: 10px 0px;
-  justify-content: center;
 }
 
 .right-of-middle-rows {

--- a/src/components/seatChart/legend/Legend.js
+++ b/src/components/seatChart/legend/Legend.js
@@ -15,7 +15,8 @@ const Legend = props => {
       </div>
       <div className="seat-legend">
         <span className="legend-icon legend-co-traveler"></span>
-        {`Co-Traveler (${props.cotravellersCount})`}
+        <Xl8 xid="resv006">Co-travelers</Xl8>
+        {` (${props.cotravellersCount})`}
       </div>
       <div className="seat-legend">
         <span className="legend-icon legend-hit"></span>

--- a/src/components/seatChart/searchSeat/SearchSeat.js
+++ b/src/components/seatChart/searchSeat/SearchSeat.js
@@ -3,25 +3,33 @@
 // Please see license.txt for details.
 
 import React from "react";
-import { Form, Button } from "react-bootstrap";
+import { Col } from "react-bootstrap";
 import { asArray, hasData, alt } from "../../../utils/utils";
+import Xl8 from "../../xl8/Xl8";
+import FilterForm from "../../filterForm2/FilterForm";
+import LabelledInput from "../../labelledInput/LabelledInput";
 
 const SearchSeat = ({ searchCallback, reservedSeats, resetFilterForm }, ref) => {
   const areEqual = (str1, str2) => {
     return alt(str1).toUpperCase() === alt(str2).toUpperCase();
   };
 
-  const reset = () => {
-    ref.current["firstName"].value = "";
-    ref.current["lastName"].value = "";
-    ref.current["middleName"].value = "";
-    resetFilterForm();
+  const cb = () => {};
+
+  // this does nothing but it satisfies FilterForm's service fxn requirement.
+  // we don't need a service since we are just filtering the data the parent provides us.
+  const noop = () => {
+    return new Promise((resolve, err) => {
+      return resolve();
+    });
   };
-  const search = () => {
+
+  // Filter the existing data and call the parent callback directly
+  const search = ev => {
     const searchFields = [];
-    if (hasData(ref.current["firstName"].value)) searchFields.push("firstName");
-    if (hasData(ref.current["lastName"].value)) searchFields.push("lastName");
-    if (hasData(ref.current["middleName"].value)) searchFields.push("middleName");
+    if (hasData(ev["firstName"])) searchFields.push("firstName");
+    if (hasData(ev["lastName"])) searchFields.push("lastName");
+    if (hasData(ev["middleName"])) searchFields.push("middleName");
 
     //If we don't have any fields to compare, return an empty array.
     if (searchFields.length === 0) {
@@ -31,7 +39,7 @@ const SearchSeat = ({ searchCallback, reservedSeats, resetFilterForm }, ref) => 
         let match = true;
 
         searchFields.forEach(searchField => {
-          if (!areEqual(currentSeat[searchField], ref.current[searchField].value)) {
+          if (!areEqual(currentSeat[searchField], ev[searchField])) {
             match = false;
             return;
           }
@@ -44,45 +52,41 @@ const SearchSeat = ({ searchCallback, reservedSeats, resetFilterForm }, ref) => 
         return result;
       }, []);
 
-      searchCallback(searchResult);
+      return searchCallback(searchResult);
     }
   };
 
   return (
-    <div className="filterform-container">
-      <Form>
-        <Form.Group>
-          <Form.Control
-            type="text"
-            ref={input => (ref.current["firstName"] = input)}
-            placeholder="First name"
-            className="search-seats-input"
+    <>
+      <Col className="notopmargin">
+        <FilterForm service={noop} paramCallback={search} callback={cb}>
+          <LabelledInput
+            labelText={<Xl8 xid="fl003">First Name</Xl8>}
+            name="firstName"
+            datafield
+            inputtype="text"
+            callback={cb}
+            alt="First Name"
           />
-        </Form.Group>
-        <Form.Group>
-          <Form.Control
-            type="text"
-            ref={input => (ref.current["middleName"] = input)}
-            placeholder="Middle name"
-            className="search-seats-input"
+          <LabelledInput
+            labelText={<Xl8 xid="fl004">Middle Name</Xl8>}
+            name="middleName"
+            datafield
+            inputtype="text"
+            callback={cb}
+            alt="Middle Name"
           />
-        </Form.Group>
-        <Form.Group>
-          <Form.Control
-            type="text"
-            ref={input => (ref.current["lastName"] = input)}
-            placeholder="Last name"
-            className="search-seats-input"
+          <LabelledInput
+            datafield
+            name="lastName"
+            labelText={<Xl8 xid="fl005">Last Name</Xl8>}
+            inputtype="text"
+            callback={cb}
+            alt="Last Name"
           />
-        </Form.Group>
-        <Button variant="dark m-1 text-white outline-dark-outline" onClick={reset}>
-          Reset
-        </Button>
-        <Button variant="primary m-1" onClick={search}>
-          Search
-        </Button>
-      </Form>
-    </div>
+        </FilterForm>
+      </Col>
+    </>
   );
 };
 

--- a/src/components/seatChart/seat/SeatInfoModal.js
+++ b/src/components/seatChart/seat/SeatInfoModal.js
@@ -11,6 +11,7 @@ import Modal, {
   ModalHeader,
   ModalTitle
 } from "../../modal/Modal";
+import { Col } from "react-bootstrap";
 
 const SeatInfoModal = props => {
   const info = props.seatInfo || {};
@@ -28,9 +29,11 @@ const SeatInfoModal = props => {
       </ModalBody>
 
       <ModalFooter>
-        <Link to={`/gtas/paxDetail/${info.flightId}/${info.paxId}`}>
-          Show passenger details
-        </Link>
+        <Col>
+          <Link to={`/gtas/paxDetail/${info.flightId}/${info.paxId}`}>
+            Show passenger details
+          </Link>
+        </Col>
       </ModalFooter>
     </Modal>
   );

--- a/src/components/seatChart/seat/SeatInfoModal.js
+++ b/src/components/seatChart/seat/SeatInfoModal.js
@@ -22,9 +22,9 @@ const SeatInfoModal = props => {
       </ModalHeader>
       <ModalBody>
         <ul style={{ listStyle: "none", paddingLeft: 0 }}>
+          <li>Last Name: {info.lastName}</li>
           <li>First Name: {info.firstName}</li>
-          <li> Last Name: {info.lastName}</li>
-          <li> Middle Name: {info.middleName}</li>
+          <li>Middle Name: {info.middleName}</li>
         </ul>
       </ModalBody>
 

--- a/src/components/seatChart/seatChartCard/SeatChartCard.js
+++ b/src/components/seatChart/seatChartCard/SeatChartCard.js
@@ -8,7 +8,7 @@ import LabelledInput from "../../labelledInput/LabelledInput";
 
 const SeatChartCard = props => {
   return (
-    <Container>
+    <Container className="m-1">
       {props.data &&
         props.data?.map((item, index) => (
           <Row key={index}>
@@ -25,7 +25,7 @@ const SeatChartCard = props => {
           </Row>
         ))}
 
-      <Row>{props.link}</Row>
+      <div>{props.link}</div>
     </Container>
   );
 };

--- a/src/components/seatChart/seatInfo/SeatInfo.js
+++ b/src/components/seatChart/seatInfo/SeatInfo.js
@@ -66,9 +66,13 @@ const SeatInfo = props => {
           />
         </Col>
       </Row>
-      <Link to={`/gtas/paxDetail/${selectedSeatInfo.flightId}/${selectedSeatInfo.paxId}`}>
-        Back to Passenger Details
-      </Link>
+      <Col>
+        <Link
+          to={`/gtas/paxDetail/${selectedSeatInfo.flightId}/${selectedSeatInfo.paxId}`}
+        >
+          Back to Passenger Details
+        </Link>
+      </Col>
     </Container>
   ) : (
     ""

--- a/src/pages/admin/settings/Settings.js
+++ b/src/pages/admin/settings/Settings.js
@@ -24,7 +24,11 @@ const Settings = () => {
     setShowModal(false);
   };
 
-  const editButton = <Button onClick={() => setShowModal(true)}>Edit Settings</Button>;
+  const editButton = (
+    <Button onClick={() => setShowModal(true)}>
+      <Xl8 xid="set007">Edit Settings</Xl8>
+    </Button>
+  );
   useEffect(() => {
     settingsinfo.get().then(res => {
       setData(res);


### PR DESCRIPTION
fixes #695 - seat-chart missing translations

* Added in missing translations
* centered the seats grid and seat info tiles text
* replaced the bootstrap Form component with FilterForm to use the built-in button translations so they stay in sync with all the other forms when translated. This also fixes a layout discrepancy with the input and label styles that did not match the other forms in the app.