### PR TITLE
fix dob filter, left-zero-pad dates

### DIFF
--- a/src/pages/flightPax/FlightPax.js
+++ b/src/pages/flightPax/FlightPax.js
@@ -2,7 +2,7 @@
 //
 // Please see license.txt for details.
 
-import React, { useContext, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import Table from "../../components/table/Table";
 import Title from "../../components/title/Title";
 import Xl8 from "../../components/xl8/Xl8";
@@ -12,6 +12,7 @@ import CountdownBadge from "../../components/countdownBadge/CountdownBadge";
 import HitsBadge from "../../components/hitsBadge/HitsBadge";
 import Main from "../../components/main/Main";
 import RoleAuthenticator from "../../context/roleAuthenticator/RoleAuthenticator";
+import ToolTipWrapper from "../../components/tooltipWrapper/TooltipWrapper";
 import { Link } from "@reach/router";
 
 import { flightPassengers } from "../../services/serviceWrapper";
@@ -23,13 +24,11 @@ import {
   localeDateOnly,
   aboveZero,
   lpad5,
-  sortableDate
+  sortableDob
 } from "../../utils/utils";
 import { LK, ROLE } from "../../utils/constants";
-import { Col, Tabs, Tab, OverlayTrigger, Popover, Tooltip } from "react-bootstrap";
+import { Col, Tabs, Tab } from "react-bootstrap";
 import "./FlightPax.css";
-import { LookupContext } from "../../context/data/LookupContext";
-import ToolTipWrapper from "../../components/tooltipWrapper/TooltipWrapper";
 
 const FlightPax = props => {
   const cb = () => {};
@@ -57,10 +56,11 @@ const FlightPax = props => {
 
   const parseData = data => {
     return asArray(data).map(item => {
-      const displayDobDate = new Date(item.dob).toLocaleDateString();
+      const displayDobDate = localeDateOnly(new Date(item.dob));
       item.docNumber = item.documents?.length > 0 ? item.documents[0] : ""; // TODO Documents: shd show all or none here.
       item.age = getAge(item.dob) ? ` (${getAge(item.dob)})` : "";
-      item.dobStr = `${sortableDate(new Date(item.dob))} ${displayDobDate} ${item.age}`;
+      item.dobStr = `${sortableDob(new Date(item.dob))} ${displayDobDate} ${item.age}`;
+
       item.dobAge = `${alt(displayDobDate)} ${item.age}`;
       item.rulehit = item.onRuleHitList ? 1 : "";
       item.watchhit = item.onWatchList ? 1 : "";
@@ -167,9 +167,9 @@ const FlightPax = props => {
     }
   ];
 
-  const arrayHeaderFixer = tab !== "hits" ? aggregateHitHeader : hitHeaders;
+  const tabSpecificHeaders = tab !== "hits" ? aggregateHitHeader : hitHeaders;
   const headers = [
-    ...arrayHeaderFixer,
+    ...tabSpecificHeaders,
     {
       Accessor: "passengerType",
       Xl8: true,
@@ -213,8 +213,7 @@ const FlightPax = props => {
       Xl8: true,
       Header: ["fp018", "DOB"],
       Cell: ({ row }) => <div>{row.original.dobAge}</div>,
-      disableGroupBy: true,
-      Aggregated: () => ``
+      disableGroupBy: true
     },
     {
       Accessor: "docNumber",

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -122,3 +122,5 @@ export const DAYS = days => {
     inSeconds: () => days * HOURS(rate).inSeconds()
   };
 };
+
+export const UNDEFINEDCHAR = "ꞏ"; // unicode U+A78F. Char not mapped to any language char, good as a delimiter.

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -2,7 +2,7 @@
 //
 // Please see license.txt for details.
 
-import { NO_URI } from "./constants";
+import { NO_URI, UNDEFINEDCHAR } from "./constants";
 // import i18n from "../i18n";
 
 // APB - shd add handling for other naming patterns like underscores and dashes, and maybe
@@ -202,8 +202,8 @@ export const localeMonthYear = val => {
   return new Date(val).toLocaleString(locale, options);
 };
 
-// sortable date string - not for display as it is not locale specific
-export const sortableDate = val => {
+// sortable date string - not for display
+export const sortableDate = (val, delim = UNDEFINEDCHAR) => {
   if (isNaN(Date.parse(val))) return "";
 
   const padDigit = num => {
@@ -212,11 +212,39 @@ export const sortableDate = val => {
 
   return (
     val.getFullYear() +
+    delim +
     padDigit(val.getMonth() + 1) +
+    delim +
     padDigit(val.getDate()) +
+    delim +
     padDigit(val.getHours()) +
+    delim +
     padDigit(val.getMinutes()) +
+    delim +
     padDigit(val.getSeconds())
+  );
+};
+
+/**
+ * Sortable date with only the year, month, day parts. The default delim value prevents the output string from inadvertently matching
+ * any user input. Not for display.
+ *
+ * @param {*} val
+ * @param {*} delim = string delimiter, defaults to the unicode char "Undefined".
+ */
+export const sortableDob = (val, delim = UNDEFINEDCHAR) => {
+  if (isNaN(Date.parse(val))) return "";
+
+  const padDigit = num => {
+    return num.toString().padStart(2, "0");
+  };
+
+  return (
+    val.getFullYear() +
+    delim +
+    padDigit(val.getMonth() + 1) +
+    delim +
+    padDigit(val.getDate())
   );
 };
 


### PR DESCRIPTION
Fixes #704 - paxdetail DOB filter inaccurate

the DOB column has a hidden sortable date that is used by the table to sort the date strings correctly. Problem is that it included time parts, so for any record the sortable date would be **YYYYMMDD000000**. This ensures the sort works, but breaks the filter because now all records will match when you type in **0**. You also get erroneous results if you type in **80** expecting to match 1980 or age 80 because you will also get records whose sortable date is like YYY**80**MDD, YYYYM**80**D, etc.

* Fixed the sortable function to exclude the timepart zeroes and added an unmapped character to the result string as a delimiter so we don't get matches across different date parts.
* Left padded the DOB months and days

To test
1. go to paxdetail
2. Enter 4 zeros ("0000") and verify no records come up
3. Enter  "83" (or similar large number) and verify all records have 83 in the column (age=83, or dob=1983)
4. Enter "12" (or similar) and verify that no records matched only because they have a month ending with 1 and a day beginning with 2
