### PR TITLE
remove filter

### DIFF
--- a/src/pages/flightPax/FlightPax.js
+++ b/src/pages/flightPax/FlightPax.js
@@ -155,6 +155,7 @@ const FlightPax = props => {
       Xl8: true,
       Header: ["fp026", "Hit Aggregates"],
       disableGroupBy: true,
+      disableFilters: true,
       aggregate: sumCotravelerHits,
       Aggregated: ({ value }) => aboveZero(value),
       Cell: ({ row }) => (


### PR DESCRIPTION
fixes #706 - remove Flight pax Hit Aggregate filter.

The filter is unnecessary and doesn't actually work.