### PR TITLE
Feat/grid filters

### DIFF
--- a/src/pages/admin/manageUsers/ManageUsers.js
+++ b/src/pages/admin/manageUsers/ManageUsers.js
@@ -196,17 +196,6 @@ const ManageUsers = props => {
     }
   ];
 
-  const button = (
-    <Button
-      variant="ternary"
-      className="btn btn-info"
-      name={props.name}
-      onClick={() => {}}
-    >
-      {addNewUser}
-    </Button>
-  );
-
   const parseData = raw => {
     return asArray(raw).map(row => {
       // Table component workaround.

--- a/src/pages/tools/queryrules/Queries.js
+++ b/src/pages/tools/queryrules/Queries.js
@@ -43,6 +43,7 @@ const Queries = props => {
       Xl8: true,
       disableSortBy: true,
       Header: ["edit001", "Edit"],
+      disableFilters: true,
       Cell: ({ row }) => (
         <div className="icon-col">
           <i
@@ -100,6 +101,7 @@ const Queries = props => {
           callback={cb}
           header={header}
           key={`table${tablekey}`}
+          enableColumnFilter={true}
         ></Table>
         <Fab
           icon={<i className="fa fa-plus nospin" />}

--- a/src/pages/tools/queryrules/QueryRules.css
+++ b/src/pages/tools/queryrules/QueryRules.css
@@ -13,6 +13,11 @@
   color: #28a745;
 }
 
+.qbrb-icon-check-red {
+  font-size: 1.4em;
+  color: #dc3545;
+}
+
 .qbrb-icon-black {
   font-size: 1.4em;
 }

--- a/src/pages/tools/queryrules/Rules.js
+++ b/src/pages/tools/queryrules/Rules.js
@@ -50,6 +50,7 @@ const Rules = props => {
       Xl8: true,
       disableSortBy: true,
       Header: ["edit001", "Edit"],
+      disableFilters: true,
       Cell: ({ row }) => (
         <div className="icon-col">
           <i
@@ -80,9 +81,17 @@ const Rules = props => {
       Accessor: "overMaxHits",
       Xl8: true,
       Header: ["rul010", "Over Max Hits"],
-      Cell: ({ row }) => (
-        <div className="icon-col">{row.original.overMaxHits ? "Yes" : "No"}</div>
-      )
+      isBoolean: true,
+      Cell: ({ row }) => {
+        if (row.original.overMaxHits === 1) {
+          return (
+            <div className="icon-col">
+              <i className="fa fa-check-square qbrb-icon-check-red"></i>
+            </div>
+          );
+        }
+        return <div className="icon-col"></div>;
+      }
     },
     { Accessor: "modifiedOn", Xl8: true, Header: ["rul011", "Modified On"] },
     { Accessor: "modifiedBy", Xl8: true, Header: ["rul012", "Modified By"] },
@@ -90,9 +99,10 @@ const Rules = props => {
     {
       Accessor: "enabled",
       Xl8: true,
+      isBoolean: true,
       Header: ["rul014", "Enabled"],
       Cell: ({ row }) => {
-        if (row.original.enabled === true) {
+        if (row.original.enabled === 1) {
           return (
             <div className="icon-col">
               <i className="fa fa-check-square qbrb-icon-check"></i>
@@ -171,7 +181,9 @@ const Rules = props => {
             hitCount: item.hitCount,
             modifiedOn: item.modifiedOn,
             modifiedBy: item.modifiedBy,
-            ...item.summary
+            ...item.summary,
+            overMaxHits: item.summary.overMaxHits === true ? 1 : 0,
+            enabled: item.summary.enabled === true ? 1 : 0
           };
         });
       }
@@ -234,7 +246,13 @@ const Rules = props => {
           leftChild={tabs}
           leftCb={titleTabCallback}
         ></Title>
-        <Table data={data} callback={cb} header={header} key={tablekey}></Table>
+        <Table
+          data={data}
+          callback={cb}
+          header={header}
+          key={tablekey}
+          enableColumnFilter={true}
+        ></Table>
         <Fab
           icon={<i className="fa fa-plus nospin" />}
           variant="info"

--- a/src/pages/tools/watchlist/Watchlist.js
+++ b/src/pages/tools/watchlist/Watchlist.js
@@ -294,6 +294,7 @@ const Watchlist = props => {
       Xl8: true,
       disableExport: true,
       disableSortBy: true,
+      disableFilters: true,
       Header: ["edit001", "Edit"],
       Cell: ({ row }) => getEditRowData(row.original)
     },
@@ -305,6 +306,7 @@ const Watchlist = props => {
       Accessor: "delete",
       Xl8: true,
       disableExport: true,
+      disableFilters: true,
       Header: ["wl014", "Delete"],
       Cell: ({ row }) => getDeleteColumnData(row.original.id)
     }
@@ -327,6 +329,7 @@ const Watchlist = props => {
         header={header}
         callback={cb}
         exportFileName={`watchlists-${wlType}`}
+        enableColumnFilter={true}
       ></Table>
       <Fab icon={<i className="fa fa-plus" />} variant="info">
         <Action text={buttonTypeText} onClick={() => launchModal(0)}>

--- a/src/pages/tools/watchlist/Watchlist.js
+++ b/src/pages/tools/watchlist/Watchlist.js
@@ -274,6 +274,7 @@ const Watchlist = props => {
       Header: ["edit001", "Edit"],
       disableExport: true,
       disableSortBy: true,
+      disableFilters: true,
       Cell: ({ row }) => getEditRowData(row.original)
     },
     { Accessor: "documentType", Xl8: true, Header: ["wl011", "Document Type"] },
@@ -283,6 +284,7 @@ const Watchlist = props => {
       Accessor: "delete",
       Xl8: true,
       Header: ["wl014", "Delete"],
+      disableFilters: true,
       disableExport: true,
       Cell: ({ row }) => getDeleteColumnData(row.original.id)
     }

--- a/src/pages/tools/watchlist/Watchlist.js
+++ b/src/pages/tools/watchlist/Watchlist.js
@@ -11,6 +11,7 @@ import WLModal from "./WLModal";
 import CSVReader from "../../../components/CSVReader/CSVReader";
 import Toast from "../../../components/toast/Toast";
 import Confirm from "../../../components/confirmationModal/Confirm";
+import { Fab, Action } from "react-tiny-fab";
 import { LookupContext } from "../../../context/data/LookupContext";
 import { wlpax, wldocs } from "../../../services/serviceWrapper";
 import { hasData, watchlistDateFormat, timezoneFreeDate } from "../../../utils/utils";
@@ -18,7 +19,6 @@ import { LK } from "../../../utils/constants";
 import "./constants.js";
 
 import { Tabs, Tab } from "react-bootstrap";
-import { Fab, Action } from "react-tiny-fab";
 import "react-tiny-fab/dist/styles.css";
 import "./Watchlist.css";
 


### PR DESCRIPTION
fixes #709 - missing grid filters on watchlist, rule, and query pages

Added filters to the headers
Modified boolean data to use boolean dropdown filters

To test:
On the Tools > Watchlist/Rules/Queries pages
verify that the grid filters work correctly for the filtered fields
verify that there are no filters for Edit or Delete columns

