### PR TITLE
fix for groupBy bug on dev

### DIFF
--- a/src/pages/flightPax/FlightPax.js
+++ b/src/pages/flightPax/FlightPax.js
@@ -214,6 +214,7 @@ const FlightPax = props => {
       Xl8: true,
       Header: ["fp018", "DOB"],
       Cell: ({ row }) => <div>{row.original.dobAge}</div>,
+      Aggregated: () => ``,
       disableGroupBy: true
     },
     {


### PR DESCRIPTION
-fixes group by issue on dev
-Anytime custom cells are used in any tables groupBy fails due to looking for generic values based on the accessors given in it, which when it constructs the new row will not actually be accessible at that level. A custom aggregator must be constructed and passed in order to satisfy its needs. In this case since need no complex aggregation on the field, we simply can leave it empty.