### PR TITLE
Fix for multi-request vetting issue

### DIFF
--- a/src/pages/vetting/Vetting.js
+++ b/src/pages/vetting/Vetting.js
@@ -245,7 +245,7 @@ const Vetting = props => {
 
   const getInitialState = () => {
     setShowDateTimePicker(false);
-    setFilterFormKey(filterFormKey + 1);
+    //setFilterFormKey(filterFormKey + 1); Initial state no longer calls, we call only once hit cats/note types are returned.
     return initialParamState;
   };
 
@@ -371,8 +371,10 @@ const Vetting = props => {
   };
 
   useEffect(() => {
-    setFilterFormKey(filterFormKey + 1);
-  }, [hitCategoryOptions, noteTypes]);
+    if(hasData(noteTypes) && hasData(hitCategoryOptions)){ //When both are fully loaded, impossible to know which one will finish first, check both
+      setFilterFormKey(filterFormKey+1);
+    }
+  }, [noteTypes, hitCategoryOptions]);
 
   useEffect(() => {
     fetchData();

--- a/src/pages/vetting/Vetting.js
+++ b/src/pages/vetting/Vetting.js
@@ -245,7 +245,7 @@ const Vetting = props => {
 
   const getInitialState = () => {
     setShowDateTimePicker(false);
-    //setFilterFormKey(filterFormKey + 1); Initial state no longer calls, we call only once hit cats/note types are returned.
+    setFilterFormKey(filterFormKey + 1);
     return initialParamState;
   };
 


### PR DESCRIPTION
Fixes #698 - Vetting fetch running 3 times on load
-Was calling on each list of categories being fetched rather than waiting for all data to be fetched, loaded, THEN make a request based on those parameters
-implemented hasData check for the types of categories, if both present THEN make call.
-removed init param request call since this is unnecessary since data is called AFTER init params are set based on table first time load anyway?
-Still extra call based on init param load, but this shaves requests down by 33%, there are solutions for the other. Will discuss before fixig.