### PR TITLE
Fix/auditlog timestamp sort

### DIFF
--- a/src/pages/admin/auditLog/AuditLog.js
+++ b/src/pages/admin/auditLog/AuditLog.js
@@ -15,7 +15,7 @@ import Main from "../../../components/main/Main";
 import { addMinutes, asArray, localeDate } from "../../../utils/utils";
 
 const AuditLog = ({ name }) => {
-  const cb = function(result) {};
+  const cb = () => {};
   const [data, setData] = useState();
   const [refreshKey, setRefreshKey] = useState(1);
   const [filterKey, setFilterKey] = useState(0);
@@ -95,7 +95,7 @@ const AuditLog = ({ name }) => {
       Accessor: "timestamp",
       Xl8: true,
       Header: ["al009", "Timestamp"],
-      Cell: ({ row }) => localeDate(row.original.timestampInMilli)
+      Cell: ({ row }) => localeDate(row.original.timestamp)
     }
   ];
 

--- a/src/pages/flightPax/FlightPax.js
+++ b/src/pages/flightPax/FlightPax.js
@@ -214,6 +214,7 @@ const FlightPax = props => {
       Xl8: true,
       Header: ["fp018", "DOB"],
       Cell: ({ row }) => <div>{row.original.dobAge}</div>,
+      Aggregated: () => ``,
       disableGroupBy: true
     },
     {


### PR DESCRIPTION
Fixes #715 - Auditlog timestamp sort not working

Pairs with backend fix under branch [fix/auditlogvoCleanup](https://github.com/US-CBP/GTAS/pull/2043) which removes unused fields and returns the timestamp ticks in the Timestamp field.