### PR TITLE
Fixes for hit category default sort and date range values not passed

### DIFF
--- a/src/components/filterForm2/FilterForm.js
+++ b/src/components/filterForm2/FilterForm.js
@@ -109,21 +109,38 @@ const FilterForm = props => {
 
   // bind children containing form data (datafield prop) to the ev handler and state
   const bindChildren = populatedFields => {
-    let boundChildren = asArray(props.children).map((child, idx) => {
-      if (!child.props?.datafield) return child;
+    let trueIndex = 0;
+    let boundChildren = [];
+    asArray(props.children).forEach((child, idx) => {
+      let trueChildCount = [];
+      if (!hasData(child.props?.datafield) && hasData(child.props?.children)) {
+        asArray(child.props.children).forEach(child => {
+          trueChildCount.push(child);
+        });
+      } else {
+        trueChildCount.push(child);
+      }
+      trueChildCount.forEach((subChild,subIdx) => { // Will usually only be 1 child
+        if (!subChild.props?.datafield) {
+          boundChildren.push(subChild);
+          return;
+        }
+        if(subIdx > 0) trueIndex++; //Track indexes for extra subchildren that wouldn't mirror parent index count
 
-      let cleanprops = Object.assign({}, child.props);
-      // intercept the callback so FilterForm is notified of input field changes.
-      // Delete it here, and replace it in newchild (below) with a FilterForm handler.
-      // We can also forward the event on to the original callback or to a parent
-      // of FilterForm if needed.
-      delete cleanprops.callback;
+        let cleanprops = Object.assign({}, subChild.props);
+        // intercept the callback so FilterForm is notified of input field changes.
+        // Delete it here, and replace it in newchild (below) with a FilterForm handler.
+        // We can also forward the event on to the original callback or to a parent
+        // of FilterForm if needed.
+        delete cleanprops.callback;
 
-      return React.cloneElement(child, {
-        key: idx,
-        callback: onChange,
-        ...cleanprops
+        boundChildren.push(React.cloneElement(subChild, {
+          key: trueIndex,
+          callback: onChange,
+          ...cleanprops
+        }));
       });
+      trueIndex++;
     });
 
     setKids(boundChildren);

--- a/src/components/filterForm2/FilterForm.js
+++ b/src/components/filterForm2/FilterForm.js
@@ -140,23 +140,35 @@ const FilterForm = props => {
     let fMap = fieldMap;
 
     asArray(props.children).forEach((child, idx) => {
-      const datafield = child.props?.datafield;
+      //Small issue with using conditional date fields, they end up as children of the property as an array of values and never get
+      //made into proper children. Check for multi-sub children and assign as top level children values.
 
-      if (datafield) {
-        const noname = `unnamedfield${idx}`;
-        const componentname = child.props.name || noname;
-        const fieldname = datafield === true ? componentname : datafield;
-        // Either the name or datafield prop must contain a string
-        if (fieldname === noname) {
-          throw new Error(`The child collection contains a "datafield" element whose name is not defined in the 
-                "name" or "datafield" props. Remove the "datafield" prop or define a name for the element.`);
-        }
-
-        fMap[componentname] = fieldname;
-        fields[fMap[componentname]] = child.props.inputval;
-
-        dfnames.push(fieldname);
+      let trueChildCount = [];
+      if(!hasData(child.props?.datafield) && hasData(child.props?.children)){
+        asArray(child.props.children).forEach(child => {
+          trueChildCount.push(child);
+        });
+      } else{
+        trueChildCount.push(child);
       }
+      trueChildCount.forEach( child => {
+        const datafield = child.props?.datafield;
+        if (datafield) {
+          const noname = `unnamedfield${idx}`;
+          const componentname = child.props.name || noname;
+          const fieldname = datafield === true ? componentname : datafield;
+          // Either the name or datafield prop must contain a string
+          if (fieldname === noname) {
+            throw new Error(`The child collection contains a "datafield" element whose name is not defined in the 
+                  "name" or "datafield" props. Remove the "datafield" prop or define a name for the element.`);
+          }
+
+          fMap[componentname] = fieldname;
+          fields[fMap[componentname]] = child.props.inputval;
+
+          dfnames.push(fieldname);
+        }
+      })
     });
 
     bindChildren(fields);

--- a/src/pages/vetting/Vetting.js
+++ b/src/pages/vetting/Vetting.js
@@ -272,6 +272,12 @@ const Vetting = props => {
   const onTableChange = () => {};
   const cb = () => {};
 
+  const initTableState = {
+    pageIndex: 0,
+    pageSize: 25,
+    sortBy: [{ id: "hitCounts", desc: true }]
+  };
+
   let startDate = new Date();
   let endDate = new Date();
   endDate.setDate(endDate.getDate() + 4);
@@ -284,6 +290,7 @@ const Vetting = props => {
   const [usersEmails, setUsersEmails] = useState({});
   const [tableKey, setTableKey] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
+  const [tableState, setTableState] = useState(initTableState);
 
   const now = new Date();
   const initialParamState = {
@@ -300,6 +307,8 @@ const Vetting = props => {
     setFilterFormKey(filterFormKey + 1);
     return initialParamState;
   };
+
+  const getTableState = () => tableState;
 
   const changeStatus = (paxId, status) => {
     const newStatus =
@@ -340,7 +349,11 @@ const Vetting = props => {
 
   const parameterAdapter = fields => {
     setIsLoading(true);
-    let paramObject = { pageSize: 500, pageNumber: 1 };
+    let sortBy = [{
+        column : "highPriorityRuleCatId",
+        dir: "asc"
+    }];
+    let paramObject = { pageSize: 500, pageNumber: 1, sort:sortBy };
     const fieldscopy = Object.assign([], fields);
     delete fieldscopy["showDateTimePicker"];
 
@@ -402,7 +415,6 @@ const Vetting = props => {
         }
       }
     });
-
     return "?requestDto=" + encodeURIComponent(JSON.stringify(paramObject));
   };
 
@@ -616,6 +628,7 @@ const Vetting = props => {
           header={Headers}
           key={tableKey}
           isLoading={isLoading}
+          stateVals={getTableState}
         />
       </Main>
     </>

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -477,3 +477,23 @@ export const getTodaysBackground = prefix => {
 
   return `${prefix}${fileIdx}`;
 };
+
+//Small issue with using conditional date fields, they end up as children of the property as an array of values and never get
+//made into proper children. Check for multi-sub children and assign as top level children values.
+export const getAllChildElements = (children) => {
+  let trueChildren = [];
+
+  const findChildren = children => {
+    asArray(children).forEach(child => {
+      if (child.props?.datafield // take top level datafield if available
+          || (!child.props?.datafield && !child.props?.children)) // If it's non standard field element, just return it as it was.
+      {trueChildren.push(child);}
+      if (!child.props?.datafield && child.props?.children) { //else keep digging
+       findChildren(child.props.children);
+      }
+    });
+  }
+
+  findChildren(children);
+  return trueChildren;
+}


### PR DESCRIPTION
-Added init table state to table on vetting page
-Added sortBy array values, passing high cat variable name for back end sorting correctly
-datefilter/daterange are bundled as an array of values for props of the filter form
-This caused emergent bug that prevented children from having their datafields properly read when present
-Filterform modified to drill minimally 1 layer deeper seeking children in order to retrieve array for proper field assignment

The table should automatically sort the front-end now based on hit category AND the back end now receives a request with the appropriate sortBy filter.

Secondly, both data range and date picker should now properly make requests with their appropriate date ranges on the vetting page.


this fixes #596 and #760