### PR TITLE
remove lane name xl8 tags

### DIFF
--- a/src/components/kanban/Kanban.js
+++ b/src/components/kanban/Kanban.js
@@ -157,7 +157,7 @@ const Kanban = props => {
       }
     });
     return {
-      name: <Xl8 xid="poe0001">{laneData.displayName}</Xl8>,
+      name: laneData.displayName,
       items: tileList,
       background: "#f0f0f0",
       dragbackground: "#c0ddec",


### PR DESCRIPTION
fixes #775 - POE duplicate lane name translations.

When entering translation mode, the POE lane names should no longer be translatable as they are already editable in Admin > Lookout Lanes.