### PR TITLE
hide the datetime picker's calendar popover

### DIFF
--- a/src/components/filterForm2/FilterForm.css
+++ b/src/components/filterForm2/FilterForm.css
@@ -11,7 +11,8 @@
 }
 
 .filterform-container .react-calendar {
-  position: fixed;
+  display: none;
+  /* position: fixed;
   top: auto;
   line-height: 0.5rem;
   border-radius: 5px;
@@ -19,7 +20,7 @@
   max-width: unset;
   left: 240px;
   bottom: 5px;
-  height: 270px;
+  height: 270px; */
 }
 
 .input:optional {


### PR DESCRIPTION
Fixes #763 - Sidebar calendar popovers are hidden.

We are just removing the popovers for now for cleaner sidebar display. Verify that the popover cannot be launched from these pages.

Vetting
poe
audit log
error log

These popovers for these modals should also not display because they were already manually disabled.
watchlist modal
qbrb modal (end date input)
