### PR TITLE
Vetting - Hits col data truncated

### DIFF
--- a/src/pages/vetting/Vetting.css
+++ b/src/pages/vetting/Vetting.css
@@ -4,9 +4,11 @@
  * Please see license.txt for details.
  */
 
-.bio-data {
+.hits-data {
+  text-align: center;
   list-style: none;
   padding-left: 0.25rem !important;
-  font-size: small;
   margin-bottom: 0px;
+  min-width: 220px;
+  white-space: nowrap;
 }

--- a/src/pages/vetting/Vetting.js
+++ b/src/pages/vetting/Vetting.js
@@ -235,18 +235,18 @@ const Vetting = props => {
       Header: ["wl020", "Hits"],
       Cell: ({ row }) => {
         const listdata = asArray(row.original.hitNames).map((hit, index) => {
-          const triggerOverlay = !isShortText(hit, 20);
+          const triggerOverlay = !isShortText(hit, 45);
           return (
             <Overlay
               trigger={triggerOverlay ? ["click", "hover"] : ""}
               key={index}
               content={hit}
             >
-              <li className={triggerOverlay ? "as-info" : ""}>{getShortText(hit, 20)}</li>
+              <li className={triggerOverlay ? "as-info" : ""}>{getShortText(hit, 45)}</li>
             </Overlay>
           );
         });
-        return <ul className="bio-data">{listdata}</ul>;
+        return <ul className="hits-data">{listdata}</ul>;
       }
     },
     {
@@ -324,16 +324,41 @@ const Vetting = props => {
     setFilterFormKey(filterFormKey + 1);
   };
 
-  const setDataWrapper = data => {
-    data = asArray(data.cases).map(item => {
-      item.id = item.id || `${item.flightId}${item.paxId}`;
-      item.carrier = item.flightNumber.slice(0, 2);
-      item.hitCounts = `${lpad5(item.highPrioHitCount)}:${lpad5(
+  const setDataWrapper = rawdata => {
+    const parseddata = asArray(rawdata.cases).map(item => {
+      const newitem = item;
+      newitem.id = item.id || `${item.flightId}${item.paxId}`;
+      newitem.carrier = item.flightNumber.slice(0, 2);
+      newitem.hitCounts = `${lpad5(item.highPrioHitCount)}:${lpad5(
         item.medPrioHitCount
       )}:${lpad5(item.lowPrioHitCount)}`;
-      return item;
+
+      // newitem.paxId = item.paxId;
+      // newitem.dob = item.dob;
+      // newitem.docType = item.docType;
+      // newitem.document = item.document;
+      // newitem.firstName = item.firstName;
+      // newitem.lastName = item.lastName;
+      // newitem.middleName = item.middleName;
+      // newitem.gender = item.gender;
+      // newitem.nationality = item.nationality;
+      // newitem.flightId = item.flightId;
+      // newitem.flightDestination = item.flightDestination;
+      // newitem.flightOrigin = item.flightOrigin;
+      // newitem.flightNumber = item.flightNumber;
+      // newitem.flightDirection = item.flightDirection;
+      // newitem.flightETADate = item.flightETADate;
+      // newitem.flightETDDate = item.flightETDDate;
+
+      // newitem.status = item.status;
+      // newitem.lookoutStatus = item.lookoutStatus;
+      // newitem.hitNames = item.hitNames;
+
+      //38
+      return newitem;
     });
-    setData(data || []);
+
+    setData(parseddata || []);
     setTableKey(tableKey + 1);
     setIsLoading(false);
   };


### PR DESCRIPTION
Fixes #374 Vetting short text is truncated at the server.

Run with backend branch [fix/vettingHitsResults](https://github.com/US-CBP/GTAS/pull/2055)

This is the final fix to the vetting page column updates. Issue was that the backend was unhelpfully pre-truncating the hits details text in addition to the front-end truncation with tooltip. We now pull the full text from the backend with the title, severity, etc concatenated into one string (which should probably be broken back out into separate fields eventually).

Also dropped all the unnecessary unused fields from the DTO/VOs, services, and model since the footprint of the resultset is already pretty big and we do not currently cache or gzip any of it. 

Hits col now has a fixed width, no-wrap, and can show the full hit title:
![vettingHitsText](https://user-images.githubusercontent.com/49160279/119697935-b92d9280-be1e-11eb-90d7-8799ab2df4d8.png)
