### PR TITLE
QBRB - bypass favorites filter for query builder calls

### DIFF
--- a/src/context/data/LookupContext.js
+++ b/src/context/data/LookupContext.js
@@ -341,6 +341,13 @@ const LookupProvider = ({ children }) => {
     });
   };
 
+  /** Refresh and return the core (name and id). Return all fields, not just favorites */
+  const getFullCachedCoreFields = (type, includeArchived) => {
+    return refresh(type).then(() => {
+      return getLookupCache(type, true, includeArchived, undefined, false);
+    });
+  };
+
   /** Refresh and return all fields for the type. Pulls from faves for carriers and airports to reduce the fetch size */
   const getCachedAllFields = (type, includeArchived) => {
     const favesOnly = hasFavorites(type);
@@ -431,6 +438,7 @@ const LookupProvider = ({ children }) => {
         getLookupState,
         getCachedAllFields,
         getCachedCoreFields,
+        getFullCachedCoreFields,
         getSingleKeyValue,
         refreshPartial,
         lookupAction

--- a/src/pages/tools/queryrules/QRModal.js
+++ b/src/pages/tools/queryrules/QRModal.js
@@ -36,16 +36,16 @@ const QRModal = props => {
   const [countries, setCountries] = useState([]);
   const [carriers, setCarriers] = useState([]);
   const [ccTypes, setCcTypes] = useState([]);
+  const [categories, setCategories] = useState([]);
   const [dataConfig, setDataConfig] = useState([]);
 
   const [title, setTitle] = useState(props.data?.title);
-  const [categories, setCategories] = useState([]);
   const [query, setQuery] = useState(props.data?.query);
   const [showInvalid, setShowInvalid] = useState(false);
   const [refresh, setRefresh] = useState(false);
   const [loaded, setLoaded] = useState(false);
   const isEdit = hasData(props.data?.id);
-  const { lookupAction, getCachedCoreFields } = useContext(LookupContext);
+  const { lookupAction, getFullCachedCoreFields } = useContext(LookupContext);
 
   useEffect(() => {
     if (
@@ -54,8 +54,9 @@ const QRModal = props => {
       hasData(airports) &&
       hasData(ccTypes) &&
       hasData(categories)
-    )
+    ) {
       setLoaded(true);
+    }
   }, [countries, carriers, airports, ccTypes, categories]);
 
   const countryProps = useMemo(() => {
@@ -594,11 +595,11 @@ const QRModal = props => {
   useEffect(() => {
     if (loaded) return;
 
-    getCachedCoreFields(LK.COUNTRY).then(res => setCountries(res));
-    getCachedCoreFields(LK.CARRIER).then(res => setCarriers(res));
-    getCachedCoreFields(LK.HITCAT).then(res => setCategories(res));
-    getCachedCoreFields(LK.AIRPORT).then(res => setAirports(res));
-    getCachedCoreFields(LK.CCTYPE).then(res => setCcTypes(res));
+    getFullCachedCoreFields(LK.COUNTRY).then(res => setCountries(res));
+    getFullCachedCoreFields(LK.CARRIER).then(res => setCarriers(res));
+    getFullCachedCoreFields(LK.HITCAT).then(res => setCategories(res));
+    getFullCachedCoreFields(LK.AIRPORT).then(res => setAirports(res));
+    getFullCachedCoreFields(LK.CCTYPE).then(res => setCcTypes(res));
 
     setData(props.data?.query);
   }, []);


### PR DESCRIPTION
fixes #787  - QRModal screen whiteout error

Updated the fetch from Lookup context to prevent filtering by favorites when pulling all data including airports. Other types were not affected because they do not have a favorites column in the IDB table.