### PR TITLE
fix icon dimensions

### DIFF
--- a/src/components/lazyImage/LazyImage.js
+++ b/src/components/lazyImage/LazyImage.js
@@ -32,7 +32,11 @@ const LazyImage = ({ val, type, size, nozoom }) => {
   return (
     <>
       {dataReady && zoomEnabled && (
-        <LazyLoad height={placeholderHeight} overflow className="lazy-image-wrapper">
+        <LazyLoad
+          height={placeholderHeight}
+          overflow
+          className={`lazy-image-wrapper ${type}`}
+        >
           <OverlayTrigger
             trigger={["click"]}
             rootClose

--- a/src/components/lazyImage/LazyImage.scss
+++ b/src/components/lazyImage/LazyImage.scss
@@ -5,11 +5,20 @@
 .lazy-image {
   background: no-repeat center center;
   background-size: cover;
-  height: 25px;
-  width: 30px;
   border-radius: 5px;
   border: 1px solid white;
+  height: 25px;
   line-height: 25px;
+}
+
+.lazy-image-wrapper.country {
+  height: 25px;
+  width: 30px;
+}
+
+.lazy-image-wrapper.carrier {
+  height: 25px;
+  width: 25px;
 }
 
 .lazy-image-full img {
@@ -55,7 +64,8 @@
 
 .filter .flight-badge .lazy-image {
   height: 50px;
-  width: 60px;
+  width: 50px;
+  margin-left: -10px;
 }
 
 .flight-badge-nonlink-icon {


### PR DESCRIPTION
fixes #783 - carrier image not square

Fixes the little icon dimensions (not the popover ones) and the flightbadge carrier icon, which is now 50 x 50.