### PR TITLE
Fix/edit user name validation

### DIFF
--- a/src/pages/admin/manageUsers/UserModal.js
+++ b/src/pages/admin/manageUsers/UserModal.js
@@ -125,13 +125,14 @@ const UserModal = props => {
 
   const validateInputs = fields => {
     let res = { ...fields[0] };
-    const validatedUsername = validateUsernameInput(res.userId);
+    const dafaultValidObj = { valid: true };
+    const validatedUsername = props.isEdit
+      ? dafaultValidObj
+      : validateUsernameInput(res.userId);
 
-    let validPassword = true;
+    const validPassword = props.isEdit ? true : isValidPassword(res.password);
 
-    if (!props.isEdit) {
-      validPassword = isValidPassword(res.password);
-    }
+
     if (!validatedUsername.valid) {
       launchAlert(validatedUsername.info);
     } else if (!validPassword) {

--- a/src/pages/admin/manageUsers/UserModal.js
+++ b/src/pages/admin/manageUsers/UserModal.js
@@ -132,7 +132,6 @@ const UserModal = props => {
 
     const validPassword = props.isEdit ? true : isValidPassword(res.password);
 
-
     if (!validatedUsername.valid) {
       launchAlert(validatedUsername.info);
     } else if (!validPassword) {


### PR DESCRIPTION
fixes #809 - Edit user errors when updating existing users

Minor - added an additional check for isEdit to prevent triggering the form error message on the User Id field on pre-submit. Existing check only handled the onchange event.