### PR TITLE
Fix/header alignment

### DIFF
--- a/src/components/title/Title.css
+++ b/src/components/title/Title.css
@@ -8,7 +8,6 @@
   display: flex;
   text-align: center;
   padding: 5px;
-  padding-top: 13px;
   position: relative;
   background-color: white;
   margin: 0px -20px;
@@ -21,12 +20,11 @@
   align-self: center;
   padding: 0px 20px;
   white-space: nowrap;
-  /* border-left: 1px solid #d0d0d0; */
-  /* border-image: linear-gradient(90deg, #d0d0d0, transparent) 1; */
 }
 
 .tab-span {
   padding: 0px 15px;
+  padding-top: 9px;
 }
 
 .action-span {

--- a/src/pages/admin/fileDownload/fileDownload.css
+++ b/src/pages/admin/fileDownload/fileDownload.css
@@ -37,5 +37,6 @@
 }
 
 .filedownload .tab-span {
-  margin-top: -8px;
+  margin-top: -3px;
+  padding-top: 0px;
 }

--- a/src/pages/paxDetail/PaxDetail.scss
+++ b/src/pages/paxDetail/PaxDetail.scss
@@ -173,5 +173,5 @@ $transparent: rgba(0, 0, 0, 0.65);
 }
 
 .paxdetail .tab-span {
-  padding-top: 2px;
+  padding-top: 9px;
 }


### PR DESCRIPTION
fixes #811 - center page titles vertically

minor css adjustment - all pages with tabs (flights, flightpax, paxdetail, admin code editor, admin filedownload, tools rules) and ensure that the header is vertically centered in its banner and has the same placement as all the other pages.