### PR TITLE
Add flightpax link and flight number to POE tile

### DIFF
--- a/src/components/kanban/Kanban.js
+++ b/src/components/kanban/Kanban.js
@@ -17,6 +17,8 @@ import LabelledInput from "../labelledInput/LabelledInput";
 import Main from "../../components/main/Main";
 import Title from "../title/Title";
 import Loading from "../../components/loading/Loading";
+import {LK} from "../../utils/constants";
+import ToolTipWrapper from "../tooltipWrapper/TooltipWrapper";
 
 const Kanban = props => {
   let startDate = new Date();
@@ -128,8 +130,15 @@ const Kanban = props => {
       content: (
         <div>
           <div className="font-weight-bolder">
-            {tileData.paxLastName}, {tileData.paxFirstName}
+            <a href={"paxDetail/"+tileData.flightId + "/" + tileData.paxId}>{tileData.paxLastName}, {tileData.paxFirstName}</a>
           </div>
+          <div>Flight #:
+            <ToolTipWrapper
+              data={{
+                val: tileData.flightNumber,
+                lkup: LK.CARRIER
+              }}
+          ></ToolTipWrapper> </div>
           <div> Doc #: {tileData.document.documentNumber}</div>
           <div>Reason: {tileData.hitCategory}</div>
           <div>&nbsp;</div>


### PR DESCRIPTION
Fixes #814 
Added flight number and flightpax link to POE tile.
Also added tooltip wrapper to flight id to match functionality in rest of site for carrier codes.

This requires a PR on the backend of the same name to be run.