### PR TITLE
minor - correct missing blur on paxdetail sidebar

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -621,3 +621,9 @@ li .rtf--ab__c button[variant="rtf-red"] {
 .margin-right-sm {
   margin-right: 5px;
 }
+
+.filterform-container {
+  overflow-x: hidden;
+  overflow-y: auto;
+  backdrop-filter: blur(10px);
+}

--- a/src/App.scss
+++ b/src/App.scss
@@ -625,5 +625,6 @@ li .rtf--ab__c button[variant="rtf-red"] {
 .filterform-container {
   overflow-x: hidden;
   overflow-y: auto;
-  backdrop-filter: blur(10px);
+  backdrop-filter: brightness(0.5) blur(3px);
+  border-bottom: 1px solid white;
 }

--- a/src/components/filterForm2/FilterForm.css
+++ b/src/components/filterForm2/FilterForm.css
@@ -4,12 +4,6 @@
  * Please see license.txt for details.
  */
 
-.filterform-container {
-  overflow-x: hidden;
-  overflow-y: auto;
-  backdrop-filter: blur(10px);
-}
-
 .filterform-container .react-calendar {
   display: none;
   /* position: fixed;

--- a/src/components/sidenavContainer/SidenavContainer.scss
+++ b/src/components/sidenavContainer/SidenavContainer.scss
@@ -161,6 +161,5 @@ hr {
 .filterform-container > form,
 .filterform-container.form {
   padding: 20px;
-  /* border-radius: 1.25rem; */
   padding-bottom: 5px;
 }


### PR DESCRIPTION
minor css conflict. One of the default styles to keep the sidebar text visible above the background image was being applied inconsistently because the style was nested under a control where it can't always (but can sometimes?) be accessed outside the component because of a reason.

Moved the css up to app (global) so the style accessible globally.

Below, the text is at least theoretically more readable with the blur.

![image](https://user-images.githubusercontent.com/49160279/121631191-991be700-ca4c-11eb-90fc-088141dfadd0.png)
