### PR TITLE
fix missing table filter cols

### DIFF
--- a/src/components/table/Table.js
+++ b/src/components/table/Table.js
@@ -407,7 +407,7 @@ const Table = props => {
       }
     });
 
-    setDisplayColumnFilter(isPopulated);
+    setDisplayColumnFilter(hasValidData);
     setParsedData(sdata);
     setHeader(sheader);
     setColumns(columns);


### PR DESCRIPTION
minor - restores the table filter row on all pages that use it.

fixes #819 - Table filters missing