### PR TITLE
Fix/unauthed request security

### DIFF
--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -3,8 +3,7 @@
 // Please see license.txt for details.
 
 import React, { useContext, useRef, useState } from "react";
-import { Link } from "@reach/router";
-import { navigate, useLocation } from "@reach/router";
+import { Link, navigate, useLocation } from "@reach/router";
 import RoleAuthenticator from "../../context/roleAuthenticator/RoleAuthenticator";
 import Toast from "../toast/Toast";
 import ChangePasswordModal from "../../pages/admin/manageUsers/changePasswordModal/ChangePasswordModal";
@@ -13,7 +12,7 @@ import { LiveEditContext } from "../../context/translation/LiveEditContext";
 import { ACTION, FULLPATH_TO, ROLE } from "../../utils/constants";
 import { hasData } from "../../utils/utils";
 import Xl8 from "../../components/xl8/Xl8";
-
+import { logout } from "../../services/serviceWrapper";
 import {
   Nav,
   Navbar,
@@ -31,14 +30,15 @@ const Header = () => {
   const { action } = useContext(LiveEditContext);
   const user = getUserState();
 
-  const logout = () => {
+  const logoff = () => {
     action({ type: "read" });
     userAction({ type: "logoff" });
+    logout.get();
 
     navigate(FULLPATH_TO.LOGIN);
   };
 
-  if (user === undefined) logout();
+  if (user === undefined) logoff();
 
   const [currentLang] = useState(window.navigator.language.split("-")[0]);
 
@@ -183,7 +183,7 @@ const Header = () => {
                 {<Xl8 xid="head005">Change password</Xl8>}
               </NavDropdown.Item>
               <NavDropdown.Divider />
-              <NavDropdown.Item onClick={logout}>
+              <NavDropdown.Item onClick={logoff}>
                 {<Xl8 xid="head006">Logout</Xl8>}
               </NavDropdown.Item>
             </NavDropdown>

--- a/src/components/xl8/Xl8.js
+++ b/src/components/xl8/Xl8.js
@@ -31,12 +31,18 @@ const Xl8 = props => {
     setIsEdit(editstate.isEdit);
   }, []);
 
+  //Force default to the default English text rather than the translation ID (xid)
+  const cleanTrans = (xid, defaultText) => {
+    const attemptedTrans = t(xid);
+    return attemptedTrans === xid ? defaultText : attemptedTrans;
+  };
+
   return isEdit ? (
     <span {...translationProps} onClick={handleClick} className="xid">
-      {t(props.xid, props.children)}
+      {cleanTrans(props.xid, props.children)}
     </span>
   ) : (
-    <span {...props}>{t(props.xid, props.children)}</span>
+    <span {...props}> {cleanTrans(props.xid, props.children)}</span>
   );
 };
 

--- a/src/context/user/UserContext.js
+++ b/src/context/user/UserContext.js
@@ -39,7 +39,6 @@ const UserProvider = ({ children }) => {
       }
       case "logoff": {
         sessionStorage.removeItem(USERSTORE);
-        Cookies.remove("JSESSIONID");
         setStorage(USERSTORE, initialState);
         return initialState;
       }

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -5,14 +5,14 @@
 import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
 import Backend from "./fetch";
-import { translations } from "./services/serviceWrapper";
+import { preauthtranslations } from "./services/serviceWrapper";
 
 const lang = window.navigator.language.split("-")[0];
 
 let prefetchedData = [];
 
 export const getI18n = () =>
-  translations.get(lang).then(data => {
+  preauthtranslations.get(lang).then(data => {
     const backendOptions = {
       parse: function() {
         return prefetchedData;
@@ -34,7 +34,7 @@ export const getI18n = () =>
       .use(Backend)
       .init({
         lng: lang,
-        fallbackLng: lang,
+        fallbackLng: "en",
         backend: backendOptions,
         keySeparator: false,
         // debug: true,

--- a/src/pages/login/ForgotPassword.js
+++ b/src/pages/login/ForgotPassword.js
@@ -2,7 +2,7 @@
 //
 // Please see license.txt for details.
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import Form from "../../components/form/Form";
 import LabelledInput from "../../components/labelledInput/LabelledInput";
 import { forgotPassword } from "../../services/serviceWrapper";
@@ -63,12 +63,12 @@ const ForgotPassword = props => {
               >
                 <LabelledInput
                   datafield
-                  labelText="User Id"
+                  labelText={<Xl8 xid="fopa002">User ID</Xl8>}
                   inputtype="text"
                   name="userId"
                   required={true}
                   inputval=""
-                  alt="nothing"
+                  alt="User ID"
                   callback={cb}
                   spacebetween
                 />

--- a/src/pages/login/Login.js
+++ b/src/pages/login/Login.js
@@ -9,7 +9,7 @@ import LabelledInput from "../../components/labelledInput/LabelledInput";
 import { navigate, Link } from "@reach/router";
 import { UserContext } from "../../context/user/UserContext";
 import { LiveEditContext } from "../../context/translation/LiveEditContext";
-import { login } from "../../services/serviceWrapper";
+import { login, logout } from "../../services/serviceWrapper";
 import { Alert, Button } from "react-bootstrap";
 
 import { FULLPATH_TO } from "../../utils/constants";
@@ -26,6 +26,7 @@ const Login = () => {
     action({ type: "hide" });
     action({ type: "dataloaded", isDataLoaded: false });
     ctx.userAction({ type: "logoff" });
+    logout.get();
   }, []);
 
   const loginHandler = (status, res) => {

--- a/src/services/genericService.js
+++ b/src/services/genericService.js
@@ -2,7 +2,9 @@
 //
 // Please see license.txt for details.
 
+import { navigate } from "@reach/router";
 import { hasData } from "../utils/utils";
+import { FULLPATH_TO } from "../utils/constants";
 import Cookies from "js-cookie";
 
 const DELETEID = "The delete method requires a valid id parameter.";
@@ -25,6 +27,11 @@ export const GenericService = async props => {
 
   return fetch(props.uri, param)
     .then(response => {
+      // APB - LOGOUT ON 401 - implement separately
+      // if (response.status === 401) {
+      //   navigate(FULLPATH_TO.LOGIN);
+      //   return [];
+      // }
       if (response === undefined) {
         return [];
       }

--- a/src/services/serviceWrapper.js
+++ b/src/services/serviceWrapper.js
@@ -12,12 +12,13 @@ import BASE_URL, {
 } from "./baseService";
 
 // pre-authentication requests
-const LOGIN = `${BASE_URL}gtas/authenticate`;
+const LOGIN = `${BASE_URL}gtas/api/authenticate`;
 const SIGNUP = `${BASE_URL}gtas/api/preauth/signup`;
 const FORGOTPASSWORD = `${BASE_URL}gtas/api/preauth/forgotpassword`;
 const FORGOTUSERNAME = `${BASE_URL}gtas/api/preauth/forgotusername`;
 const PHYSICALLOCATIONS = `${BASE_URL}gtas/api/preauth/locations`;
 
+const LOGOUT = `${BASE_URL}gtas/api/logout`;
 const USERS = `${BASE_URL}gtas/users`;
 const RESETPASSWORD = `${BASE_URL}gtas/reset-password`;
 const MANAGEUSERS = `${BASE_URL}gtas/manageuser`;
@@ -236,6 +237,10 @@ export const login = {
       return get(LOGGEDIN_USER, BASEHEADER);
     });
   }
+};
+
+export const logout = {
+  get: () => get(LOGOUT, BASEHEADER)
 };
 
 export const query = {

--- a/src/services/serviceWrapper.js
+++ b/src/services/serviceWrapper.js
@@ -17,6 +17,7 @@ const SIGNUP = `${BASE_URL}gtas/api/preauth/signup`;
 const FORGOTPASSWORD = `${BASE_URL}gtas/api/preauth/forgotpassword`;
 const FORGOTUSERNAME = `${BASE_URL}gtas/api/preauth/forgotusername`;
 const PHYSICALLOCATIONS = `${BASE_URL}gtas/api/preauth/locations`;
+const PREAUTHTRANSLATIONS = `${BASE_URL}gtas/api/preauth/translation`;
 
 const LOGOUT = `${BASE_URL}gtas/api/logout`;
 const USERS = `${BASE_URL}gtas/users`;
@@ -75,6 +76,10 @@ const POETILES = `${BASE_URL}gtas/api/POE/tiles`;
 export const translations = {
   get: id => get(TRANSLATIONS, BASEHEADER, id),
   post: body => post(TRANSLATIONS, BASEHEADER, stringify(body))
+};
+
+export const preauthtranslations = {
+  get: id => get(PREAUTHTRANSLATIONS, BASEHEADER, id)
 };
 
 export const users = {

--- a/src/services/serviceWrapper.js
+++ b/src/services/serviceWrapper.js
@@ -11,8 +11,15 @@ import BASE_URL, {
   stringify
 } from "./baseService";
 
+// pre-authentication requests
 const LOGIN = `${BASE_URL}gtas/authenticate`;
+const SIGNUP = `${BASE_URL}gtas/api/preauth/signup`;
+const FORGOTPASSWORD = `${BASE_URL}gtas/api/preauth/forgotpassword`;
+const FORGOTUSERNAME = `${BASE_URL}gtas/api/preauth/forgotusername`;
+const PHYSICALLOCATIONS = `${BASE_URL}gtas/api/preauth/locations`;
+
 const USERS = `${BASE_URL}gtas/users`;
+const RESETPASSWORD = `${BASE_URL}gtas/reset-password`;
 const MANAGEUSERS = `${BASE_URL}gtas/manageuser`;
 const USERSNONARCHIVED = `${USERS}/nonarchived`;
 const USERSEMAIL = `${BASE_URL}gtas/users/emails`;
@@ -50,14 +57,9 @@ const CYPHER = HOST + "cypherUrl";
 const CYPHERAUTH = HOST + "cypherAuth";
 const MANUALHIT = `${BASE_URL}gtas/createmanualpvl`;
 const LOGFILE = `${BASE_URL}gtas/api/logs/`;
-const SIGNUP = `${BASE_URL}gtas/user/signup/new`;
-const PHYSICALLOCATIONS = `${BASE_URL}gtas/user/signup/physiclLocations`;
 const SIGNUPREQUESTS = `${BASE_URL}gtas/api/signup-requests`;
 const SIGNUPREQUESTAPPROVE = `${BASE_URL}gtas/signupRequest/approve`;
 const SIGNUPREQUESTSREJECT = `${BASE_URL}gtas/signupRequest/reject`;
-const FORGOTPASSWORD = `${BASE_URL}gtas/forgot-password`;
-const FORGOTUSERNAME = `${BASE_URL}gtas/forgot-username`;
-const RESETPASSWORD = `${BASE_URL}gtas/reset-password`;
 const SEARCH = `${BASE_URL}gtas/search`;
 const SEATS = `${BASE_URL}gtas/seats`;
 const ATTACHMENTS = `${BASE_URL}gtas/attachments`;


### PR DESCRIPTION
fixes #808 - Forgot username form issues.   Pairs with backend PR on the same branch name

Fixes the forgot username form not responding correctly to submissions.

Added a preauth prefix to api endpoints that don't need authentication
Added a logout call to terminate the session server-side
Added a missing xl8 tag
Added a separate preauth endpoint for translations




