### PR TITLE
rem erroneous space in translation return

### DIFF
--- a/src/components/countdownBadge/CountdownBadge.js
+++ b/src/components/countdownBadge/CountdownBadge.js
@@ -54,7 +54,7 @@ const CountdownBadge = props => {
   const h = <Xl8 xid="cdb002">h</Xl8>;
   const m = <Xl8 xid="cdb003">m</Xl8>;
   const formatedDays = days ? (
-    <span className="">
+    <span>
       {days}
       {d}
     </span>
@@ -62,7 +62,7 @@ const CountdownBadge = props => {
     days
   );
   const formatedHours = hours ? (
-    <span className="">
+    <span>
       {hours}
       {h}
     </span>
@@ -70,7 +70,7 @@ const CountdownBadge = props => {
     hours
   );
   const formatedMinutes = minutes ? (
-    <span className="">
+    <span>
       {minutes}
       {m}
     </span>

--- a/src/components/xl8/Xl8.js
+++ b/src/components/xl8/Xl8.js
@@ -42,7 +42,7 @@ const Xl8 = props => {
       {cleanTrans(props.xid, props.children)}
     </span>
   ) : (
-    <span {...props}> {cleanTrans(props.xid, props.children)}</span>
+    <span {...props}>{cleanTrans(props.xid, props.children)}</span>
   );
 };
 


### PR DESCRIPTION
fixes #826 - extra space in the translation results

simple fix to remove a space in the returned tag and value from the xl8 tag. Also removed unused className props from the badge.